### PR TITLE
fix: exit insert mode after selecting an entry in Telescope

### DIFF
--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -240,6 +240,7 @@ function M.show_telescope_picker()
 		previewer = package_previewer,
 		attach_mappings = function(_, map)
 			map("i", "<CR>", function(prompt_bufnr)
+				vim.cmd("stopinsert")
 				on_package_select(prompt_bufnr)
 			end)
 			map("n", "<CR>", function(prompt_bufnr)


### PR DESCRIPTION
Hi!

I just installed the plugin and it’s amazing! However, I noticed a small issue: when selecting an entry with Telescope in insert mode, it switches to the documentation split but stays in insert mode. 

This fix forces it to switch to normal mode instead.

Thank you for the awesome project, and I hope this helps!