### PR TITLE
feat!: rewrite for extensibility

### DIFF
--- a/lua/godoc/adapters/go.lua
+++ b/lua/godoc/adapters/go.lua
@@ -1,0 +1,227 @@
+local M = {}
+
+-- Cache for package list
+local package_cache = nil
+local package_cache_time = 0
+local package_cache_cwd = vim.fn.getcwd()
+local CACHE_DURATION = 300 -- 5 minutes
+
+---Get standard library packages from 'go list'
+---@returns table<string>
+local function get_std_packages_golist()
+	local std_packages = vim.fn.systemlist("go list std")
+	if vim.v.shell_error ~= 0 then
+		vim.notify("Failed to get package list using 'go list'", vim.log.levels.ERROR)
+		return {}
+	end
+	return std_packages
+end
+
+---Get standard library packages from stdsym, if binary is available
+---@returns table<string>
+local function get_std_packages_stdsym()
+	local stdsym = vim.fn.executable("stdsym")
+	if stdsym == 1 then
+		-- stdsym is available
+		local std_packages_via_stdsym = vim.fn.systemlist("stdsym")
+		if vim.v.shell_error ~= 0 then
+			vim.notify("Failed to get package list using stdsym, falling back on 'go list'", vim.log.levels.ERROR)
+			return get_std_packages_golist()
+		end
+		return std_packages_via_stdsym
+	end
+
+	-- stdsym is not available, fall back to using `go list std`
+	return get_std_packages_golist()
+end
+
+---Get project and dependency packages, if in a Go module
+---@returns table<strings
+local function get_gomod_packages()
+	-- Search from the directory of the current file upwards until it finds the file "go.mod"
+	local go_mod = vim.fn.findfile("go.mod", ".;")
+	if go_mod ~= "" then
+		-- Get the directory containing go.mod
+		local mod_dir = vim.fn.fnamemodify(go_mod, ":p:h")
+		-- Execute go list all in the module directory
+		local mod_packages = vim.fn.systemlist(string.format("cd %s && go list -e all", vim.fn.shellescape(mod_dir)))
+		if vim.v.shell_error ~= 0 then
+			vim.notify("Failed to get package list using 'go list'", vim.log.levels.ERROR)
+			return {}
+		end
+		return mod_packages
+	end
+	return {} -- no go.mod file found
+end
+
+--- Get list of packages
+---@return table<string>
+local function get_packages()
+	-- Check cache
+	local current_time = os.time()
+	if
+		package_cache
+		and (current_time - package_cache_time) < CACHE_DURATION
+		and package_cache_cwd == vim.fn.getcwd()
+	then
+		return package_cache
+	end
+
+	local std_packages = get_std_packages_stdsym()
+	local gomod_packages = get_gomod_packages()
+	local all_packages = {}
+	for _, pkg in ipairs(std_packages) do
+		table.insert(all_packages, pkg)
+	end
+	for _, pkg in ipairs(gomod_packages) do
+		table.insert(all_packages, pkg)
+	end
+
+	-- Update cache
+	package_cache = vim.fn.uniq(all_packages)
+	package_cache_time = current_time
+
+	return all_packages
+end
+
+local function health()
+	--- @type GoDocHealthCheck[]
+	local checks = {}
+
+	-- Check if 'go' is available
+	local go_version = vim.fn.system("go version")
+	if vim.v.shell_error == 0 then
+		table.insert(checks, {
+			ok = true,
+			message = "go binary found: " .. go_version:gsub("\n", ""),
+		})
+	else
+		table.insert(checks, {
+			ok = false,
+			message = "go binary not found in PATH",
+		})
+	end
+
+	-- Check if 'stdsym' is available in PATH
+	local stdsym = vim.fn.executable("stdsym")
+	if stdsym == 1 then
+		table.insert(checks, {
+			ok = true,
+			message = "stdsym binary found",
+		})
+	else
+		table.insert(checks, {
+			ok = false,
+			message = "stdsym binary not found in PATH",
+			optional = true,
+		})
+	end
+
+	-- Check if we can run 'go help doc'
+	local go_help_doc = vim.fn.system("go help doc")
+	if vim.v.shell_error == 0 then
+		table.insert(checks, {
+			ok = true,
+			message = "go help doc command found",
+		})
+	else
+		table.insert(checks, {
+			ok = false,
+			message = "go help doc command not found",
+			optional = true,
+		})
+	end
+
+	-- Check if we can run 'go list std'
+	local go_list_std = vim.fn.system("go list std")
+	if vim.v.shell_error == 0 then
+		table.insert(checks, {
+			ok = true,
+			message = "go list std command found",
+		})
+	else
+		table.insert(checks, {
+			ok = false,
+			message = "go list std command not found",
+			optional = true,
+		})
+	end
+
+	-- Check if we can run 'go doc fmt'
+	local go_doc_fmt = vim.fn.system("go doc fmt")
+	if vim.v.shell_error == 0 then
+		table.insert(checks, {
+			ok = true,
+			message = "go doc fmt command found",
+		})
+	else
+		table.insert(checks, {
+			ok = false,
+			message = "go doc fmt command not found",
+			optional = true,
+		})
+	end
+
+	-- Check if we can run 'go doc fmt.Printf'
+	local go_doc_fmt_printf = vim.fn.system("go doc fmt.Printf")
+	if vim.v.shell_error == 0 then
+		table.insert(checks, {
+			ok = true,
+			message = "go doc fmt.Printf command found",
+		})
+	else
+		table.insert(checks, {
+			ok = false,
+			message = "go doc fmt.Printf command not found",
+			optional = true,
+		})
+	end
+
+	-- Check if we're in a Go project (optional)
+	local go_mod = vim.fn.findfile("go.mod", ".;")
+	if go_mod ~= "" then
+		table.insert(checks, {
+			ok = true,
+			message = "Go project detected",
+			optional = true,
+		})
+	else
+		table.insert(checks, {
+			ok = false,
+			message = "Go project not detected",
+			optional = true,
+		})
+	end
+
+	return checks
+end
+
+---Set up the GoDoc adapter
+---@param opts? table
+--- @return GoDocAdapter
+function M.setup(opts)
+	if not opts then
+		opts = {}
+	end
+	return {
+		command = opts.command or "GoDoc",
+		get_items = opts.get_items or function()
+			-- default implementation
+			return get_packages()
+		end,
+		get_content = opts.get_content or function(choice)
+			-- default implementation
+			return vim.fn.systemlist("go doc -all " .. choice)
+		end,
+		get_syntax_info = opts.get_syntax_info or function()
+			-- default implementation
+			return {
+				filetype = "godoc",
+				language = "go",
+			}
+		end,
+		health = opts.health or health,
+	}
+end
+
+return M

--- a/lua/godoc/adapters/init.lua
+++ b/lua/godoc/adapters/init.lua
@@ -1,0 +1,58 @@
+local M = {}
+
+-- Available adapters and their default options
+--- @type table<string, fun(opts: table): GoDocAdapter>
+M.available_adapters = {
+	go = require("godoc.adapters.go").setup,
+}
+
+--- Get list of available built-in adapter names
+--- @return string[]
+function M.get_available_adapter_names()
+	return vim.tbl_keys(M.available_adapters)
+end
+
+--- Check if an adapter name exists in built-in adapters
+--- @param name string
+--- @return boolean
+function M.has_adapter(name)
+	return M.available_adapters[name] ~= nil
+end
+
+--- Get a built-in adapter by name
+--- @param name string
+--- @param opts? GoDocAdapterOpts
+--- @return GoDocAdapter|nil
+function M.get_adapter(name, opts)
+	local setup_fn = M.available_adapters[name]
+	if setup_fn then
+		return setup_fn(opts or {})
+	end
+	return nil
+end
+
+--- Validate if a table matches the DocAdapter interface
+--- @param adapter any
+--- @return boolean, string?
+function M.validate_adapter(adapter)
+	if type(adapter) ~= "table" then
+		return false, "Adapter must be a table"
+	end
+
+	local required_fields = {
+		{ name = "command", type = "string" },
+		{ name = "get_items", type = "function" },
+		{ name = "get_content", type = "function" },
+		{ name = "get_syntax_info", type = "function" },
+	}
+
+	for _, field in ipairs(required_fields) do
+		if type(adapter[field.name]) ~= field.type then
+			return false, string.format("Adapter must have a '%s' field of type '%s'", field.name, field.type)
+		end
+	end
+
+	return true
+end
+
+return M

--- a/lua/godoc/health.lua
+++ b/lua/godoc/health.lua
@@ -1,117 +1,42 @@
--- lua/godoc/health.lua
 local health = vim.health or require("health")
-local start = health.start or health.report_start
-local ok = health.ok or health.report_ok
-local error = health.error or health.report_error
-local warn = health.warn or health.report_warn
-local info = health.info or health.report_info
 
 local M = {}
 
--- Helper function to safely get environment variables
-local function get_env(name)
-	local value = vim.fn.getenv(name)
-	return type(value) == "string" and value or ""
-end
-
 function M.check()
-	start("godoc.nvim")
+	health.start("godoc.nvim")
 
-	-- Check if 'go' is available in PATH
-	local go_binary = vim.fn.executable("go")
-	if go_binary == 1 then
-		ok("'go' binary found in PATH")
+	-- Check plugin setup
+	local config = require("godoc").config
+	if not config then
+		health.error("Plugin not configured")
+		return
+	else
+		health.ok("Plugin configured")
+	end
 
-		-- Check go version
-		local version = vim.fn.system("go version")
-		if vim.v.shell_error == 0 then
-			ok(string.format("Go version: %s", version:gsub("\n", "")))
+	local configured_adapters = require("godoc").configured_adapters
+	for _, adapter in ipairs(configured_adapters) do
+		-- Get adapter name for display
+		local name = adapter.command
+		health.start(name)
+
+		-- Run adapter health checks if available
+		if adapter.health then
+			local checks = adapter.health()
+			for _, check in ipairs(checks) do
+				if check.ok then
+					health.ok(check.message)
+				else
+					if check.optional then
+						health.warn(check.message)
+					else
+						health.error(check.message)
+					end
+				end
+			end
 		else
-			error("Failed to get Go version")
+			health.info("No health checks implemented")
 		end
-	else
-		error("'go' binary not found in PATH")
-		return
-	end
-
-	-- Check if 'stdsym' is available in PATH
-	local stdsym_binary = vim.fn.executable("stdsym")
-	if stdsym_binary == 1 then
-		ok("'stdsym' binary found in PATH")
-	else
-		error("'stdsym' binary not found in PATH")
-		return
-	end
-
-	-- Check if we can get doc help
-	local help_test = vim.fn.system("go help doc")
-	if vim.v.shell_error == 0 then
-		ok("'go help doc' command is working")
-	else
-		error("'go help doc' command failed", {
-			"Error running 'go help doc'",
-			"Output: " .. help_test,
-		})
-		return
-	end
-
-	-- Check if we can list packages
-	local list_test = vim.fn.system("go list std")
-	if vim.v.shell_error == 0 then
-		ok("'go list' command is working")
-	else
-		error("'go list' command failed", {
-			"Error running 'go list std'",
-			"Output: " .. list_test,
-		})
-		return
-	end
-
-	-- Check if we can run basic go doc command
-	local doc_test = vim.fn.system("go doc fmt")
-	if vim.v.shell_error == 0 then
-		ok("'go doc' package lookup is working")
-	else
-		error("'go doc' package lookup failed", {
-			"Error running 'go doc fmt'",
-			"Output: " .. doc_test,
-		})
-		return
-	end
-
-	-- Check if we can look up specific symbols
-	local symbol_test = vim.fn.system("go doc fmt.Printf")
-	if vim.v.shell_error == 0 then
-		ok("'go doc' symbol lookup is working")
-	else
-		error("'go doc' symbol lookup failed", {
-			"Error running 'go doc fmt.Printf'",
-			"Output: " .. symbol_test,
-		})
-	end
-
-	-- Check if we're in a Go project (optional)
-	local go_mod = vim.fn.findfile("go.mod", ".;")
-	if go_mod ~= "" then
-		ok("Found go.mod file: " .. go_mod)
-	else
-		info("No go.mod file found in current directory or parent directories")
-	end
-
-	-- Check GOPATH environment
-	local gopath = get_env("GOPATH")
-	if gopath ~= "" then
-		ok("GOPATH is set: " .. gopath)
-	else
-		warn("GOPATH is not set")
-	end
-
-	-- Check GOROOT environment
-	local goroot = get_env("GOROOT")
-	if goroot ~= "" then
-		ok("GOROOT is set: " .. goroot)
-	else
-		warn("GOROOT is not set")
 	end
 end
 

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -1,380 +1,141 @@
+require("godoc.types")
+local pickers = require("godoc.pickers")
+local adapters = require("godoc.adapters")
+
 local M = {}
 
 -- Default configuration.
-M.config = {
-	command = "GoDoc",
-	window = {
-		type = "split", -- split or vsplit
+--- @type GoDocConfig
+M.defaults = {
+	adapters = {
+		{
+			name = "go",
+			opts = { command = "GoDoc" },
+		},
 	},
-	highlighting = {
-		language = "go",
+	window = {
+		type = "split", -- split, vsplit
 	},
 	picker = {
-		type = "native", -- native or snacks
-		snacks_options = {
-			layout = {
-				layout = {
-					height = 0.8,
-					width = 0.9, -- Take up 90% of the total width (adjust as needed)
-					box = "horizontal", -- Horizontal layout (input and list on the left, preview on the right)
-					{ -- Left side (input and list)
-						box = "vertical",
-						width = 0.3, -- List and input take up 30% of the width
-						border = "rounded",
-						{ win = "input", height = 1, border = "bottom" },
-						{ win = "list", border = "none" },
-					},
-					{ win = "preview", border = "rounded", width = 0.7 }, -- Preview window takes up 70% of the width
-				},
-			},
-			win = {
-				preview = {
-					wo = { wrap = true },
-				},
-			},
-		},
+		type = "native", -- native | telescope | snacks | mini
+
+		-- see respective picker in lua/godoc/pickers for available options
+		native = {},
+		telescope = {},
+		snacks = {},
+		mini = {},
 	},
 }
 
--- Check if go is available
-local function check_requirements()
-	if vim.fn.executable("go") == 0 then
-		return false, "'go' binary not found in PATH"
+-- Final configuration (defaults + user-provided) after setup.
+--- @type GoDocConfig
+M.config = nil
+
+-- The configured adapters, after having set them up.
+--- @type GoDocAdapter[]
+M.configured_adapters = {}
+
+--- @param config? GoDocConfig
+--- @return GoDocAdapter[]
+local function configure_adapters(config)
+	if not config or not config.adapters or type(config.adapters) ~= "table" then
+		vim.notify("Invalid configuration: adapters must be a list", vim.log.levels.ERROR)
+		return {}
 	end
 
-	-- Test go doc functionality
-	local test = vim.fn.system("go doc fmt")
-	if vim.v.shell_error ~= 0 then
-		return false, "'go doc' command failed. Please run :checkhealth godoc for more information"
+	local configured_adapters = {}
+
+	for _, adapter_config in ipairs(config.adapters) do
+		if type(adapter_config) == "table" then
+			if adapter_config.setup and type(adapter_config.setup) == "function" then
+				-- Handle third-party adapter
+				local base_adapter = adapter_config.setup() -- Get adapter without passing opts
+				local final_adapter = vim.tbl_deep_extend("force", base_adapter, adapter_config.opts or {})
+				local is_valid, error_message = adapters.validate_adapter(final_adapter)
+				if is_valid then
+					table.insert(configured_adapters, final_adapter)
+				else
+					vim.notify(string.format("Invalid third-party adapter: %s", error_message), vim.log.levels.WARN)
+				end
+			elseif adapter_config.name and adapters.has_adapter(adapter_config.name) then
+				-- Handle built-in adapter
+				local adapter = adapters.get_adapter(adapter_config.name, adapter_config.opts)
+				if adapter then
+					table.insert(configured_adapters, adapter)
+				end
+			else
+				-- Handle user-defined adapter
+				local is_valid, error_message = adapters.validate_adapter(adapter_config)
+				if is_valid then
+					table.insert(configured_adapters, adapter_config)
+				else
+					vim.notify(string.format("Invalid user-defined adapter: %s", error_message), vim.log.levels.WARN)
+				end
+			end
+		end
 	end
 
-	return true, nil
+	return configured_adapters
 end
 
 -- Set up the plugin with user config
+--- @param opts? GoDocConfig
 function M.setup(opts)
-	M.config = vim.tbl_deep_extend("force", M.config, opts or {})
+	M.config = vim.tbl_deep_extend("force", M.defaults, opts or {})
+	M.configured_adapters = configure_adapters(M.config)
 
-	-- Set up syntax highlighting
-	vim.treesitter.language.register(M.config.highlighting.language, { "godoc" })
+	for _, adapter in ipairs(M.configured_adapters) do
+		-- Set up syntax highlighting
+		vim.treesitter.language.register(adapter.get_syntax_info().language, { adapter.get_syntax_info().filetype })
 
-	-- Create user command
-	vim.api.nvim_create_user_command(M.config.command, function(args)
-		-- Check requirements
-		local ok, err = check_requirements()
-		if not ok then
-			vim.notify(string.format("godoc.nvim: %s", err), vim.log.levels.ERROR)
-			return
-		end
-
-		-- if args were passed, show documentation directly
-		if args.args ~= nil and args.args ~= "" then
-			M.show_documentation(args.args)
-			return
-		end
-
-		if M.config.picker.type == "native" then
-			M.show_native_picker()
-		elseif M.config.picker.type == "telescope" then
-			M.show_telescope_picker()
-		elseif M.config.picker.type == "snacks" then
-			M.show_snacks_picker()
-		elseif M.config.picker.type == "mini" then
-			M.show_mini_picker()
-		else
-			vim.notify("Picker not implemented: " .. M.config.picker.type, vim.log.levels.ERROR)
-		end
-	end, { nargs = "?" })
-end
-
----Get standard library packages from 'go list'
----@returns table<string>
-local function get_std_packages_golist()
-	local std_packages = vim.fn.systemlist("go list std")
-	if vim.v.shell_error ~= 0 then
-		vim.notify("Failed to get package list using 'go list'", vim.log.levels.ERROR)
-		return {}
-	end
-	return std_packages
-end
-
----Get standard library packages from stdsym, if binary is available
----@returns table<string>
-local function get_std_packages_stdsym()
-	local stdsym = vim.fn.executable("stdsym")
-	if stdsym == 1 then
-		-- stdsym is available
-		local std_packages_via_stdsym = vim.fn.systemlist("stdsym")
-		if vim.v.shell_error ~= 0 then
-			vim.notify("Failed to get package list using stdsym, falling back on 'go list'", vim.log.levels.ERROR)
-			return get_std_packages_golist()
-		end
-		return std_packages_via_stdsym
-	end
-
-	-- stdsym is not available, fall back to using `go list std`
-	return get_std_packages_golist()
-end
-
----Get project and dependency packages, if in a Go module
----@returns table<strings
-local function get_gomod_packages()
-	-- Search from the directory of the current file upwards until it finds the file "go.mod"
-	local go_mod = vim.fn.findfile("go.mod", ".;")
-	if go_mod ~= "" then
-		-- Get the directory containing go.mod
-		local mod_dir = vim.fn.fnamemodify(go_mod, ":p:h")
-		-- Execute go list all in the module directory
-		local mod_packages = vim.fn.systemlist(string.format("cd %s && go list -e all", vim.fn.shellescape(mod_dir)))
-		if vim.v.shell_error ~= 0 then
-			vim.notify("Failed to get package list using 'go list'", vim.log.levels.ERROR)
-			return {}
-		end
-		return mod_packages
-	end
-	return {} -- no go.mod file found
-end
-
--- Cache for package list
-local package_cache = nil
-local package_cache_time = 0
-local package_cache_cwd = vim.fn.getcwd()
-local CACHE_DURATION = 300 -- 5 minutes
-
---- Get list of packages
----@return table<string>
-local function get_packages()
-	-- Check cache
-	local current_time = os.time()
-	if
-		package_cache
-		and (current_time - package_cache_time) < CACHE_DURATION
-		and package_cache_cwd == vim.fn.getcwd()
-	then
-		return package_cache
-	end
-
-	local std_packages = get_std_packages_stdsym()
-	local gomod_packages = get_gomod_packages()
-	local all_packages = {}
-	for _, pkg in ipairs(std_packages) do
-		table.insert(all_packages, pkg)
-	end
-	for _, pkg in ipairs(gomod_packages) do
-		table.insert(all_packages, pkg)
-	end
-
-	-- Update cache
-	package_cache = vim.fn.uniq(all_packages)
-	package_cache_time = current_time
-
-	return all_packages
-end
-
--- Show Neovim-native picker
-function M.show_native_picker()
-	-- Show native picker with packages
-	vim.ui.select(get_packages(), {
-		prompt = "Select Go Package:",
-		format_item = function(item)
-			return item
-		end,
-	}, function(choice)
-		if choice then
-			M.show_documentation(choice)
-		end
-	end)
-end
-
--- Show telescope picker
-function M.show_telescope_picker()
-	local action_state = require("telescope.actions.state")
-	local finders = require("telescope.finders")
-	local pickers = require("telescope.pickers")
-	local previewers = require("telescope.previewers")
-	local conf = require("telescope.config").values
-
-	local function go_packages_finder(opts, ctx)
-		local output = get_packages()
-		local items = {}
-		for _, package_name in ipairs(output) do
-			table.insert(items, {
-				value = package_name,
-				display = package_name,
-				ordinal = package_name,
-			})
-		end
-		return items
-	end
-
-	-- Create custom previewer
-	local package_previewer = previewers.new_buffer_previewer({
-		title = "Package Documentation",
-		get_buffer_by_name = function(_, entry)
-			return entry.value
-		end,
-		define_preview = function(self, entry)
-			local docs = M.get_documentation(entry.value)
-			vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, docs)
-			vim.api.nvim_set_option_value("filetype", "godoc", { buf = self.state.bufnr })
-		end,
-	})
-
-	local function on_package_select(prompt_bufnr)
-		local selection = action_state.get_selected_entry()
-		if selection then
-			M.show_documentation(selection.value)
-		end
-	end
-
-	local opts = {
-		finder = finders.new_table({
-			results = go_packages_finder(),
-			entry_maker = function(entry)
-				return {
-					display = entry.display,
-					value = entry.value,
-					ordinal = entry.ordinal,
-				}
-			end,
-		}),
-		sorter = conf.generic_sorter(),
-		previewer = package_previewer,
-		attach_mappings = function(_, map)
-			map("i", "<CR>", function(prompt_bufnr)
-				vim.cmd("stopinsert")
-				on_package_select(prompt_bufnr)
-			end)
-			map("n", "<CR>", function(prompt_bufnr)
-				on_package_select(prompt_bufnr)
-			end)
-			return true
-		end,
-	}
-
-	if M.config and M.config.picker and M.config.picker.telescope_options then
-		opts = vim.tbl_extend("force", opts, M.config.picker.telescope_options)
-	end
-
-	pickers.new(opts, {}):find()
-end
-
--- Show Snacks picker
-function M.show_snacks_picker()
-	local snacks = require("snacks")
-
-	local function go_packages_finder(opts, ctx)
-		local output = get_packages()
-		local items = {}
-		for _, package_name in ipairs(output) do
-			table.insert(items, {
-				text = package_name, -- The package name as the main text in the picker
-				package_name = package_name, -- Store the package name for the action
-			})
-		end
-		return items
-	end
-
-	local function on_package_select(package_name)
-		M.show_documentation(package_name)
-	end
-
-	local opts = {
-		finder = go_packages_finder,
-		format = "text",
-		title = "Go Standard Packages",
-		preview = function(ctx)
-			if ctx.item then
-				local package_name = ctx.item.package_name
-				ctx.preview:set_lines(M.get_documentation(package_name))
-				ctx.preview:highlight({ ft = "godoc" })
-			else
-				ctx.preview:reset()
+		-- Create user command
+		vim.api.nvim_create_user_command(adapter.command, function(args)
+			-- if args were passed, show documentation directly
+			if args.args ~= nil and args.args ~= "" then
+				M.show_documentation(adapter, args.args)
+				return
 			end
-		end,
-		actions = {
-			confirm = function(picker, item)
-				if item then
-					snacks.picker.actions.close(picker) -- Close the picker
-					on_package_select(item.package_name) -- Call your custom action
-				end
-			end,
-		},
-	}
 
-	if M.config and M.config.picker and M.config.picker.snacks_options then
-		opts = vim.tbl_extend("force", opts, M.config.picker.snacks_options)
+			-- Show picker
+			local picker = pickers.get_picker(M.config.picker.type)
+			if picker then
+				---@type GoDocPicker
+				picker.show(adapter, M.config, function(choice)
+					if choice then
+						M.show_documentation(adapter, choice)
+					end
+				end)
+			else
+				vim.notify("Picker not implemented: " .. M.config.picker.type, vim.log.levels.ERROR)
+			end
+		end, { nargs = "?" })
 	end
-
-	snacks.picker.pick(opts)
-end
-
--- Show Mini picker
-function M.show_mini_picker()
-	local minipick = require("mini.pick")
-
-	local opts = {
-		source = {
-			items = get_packages(),
-			name = "Go Standard Packages",
-			preview = function(buf_id, item)
-				local doc = M.get_documentation(item)
-				vim.api.nvim_buf_set_lines(buf_id, 0, -1, false, doc)
-				vim.api.nvim_set_option_value("filetype", "godoc", { buf = buf_id })
-			end,
-			choose = function(item)
-				M.show_documentation(item)
-			end,
-		},
-	}
-
-	if M.config and M.config.picker and M.config.picker.mini_options then
-		opts = vim.tbl_extend("force", opts, M.config.picker.mini_options)
-	end
-
-	minipick.start(opts)
-end
-
--- Package docs cache
-local package_docs = {}
-
--- Get the documentation
-function M.get_documentation(package_name)
-	if package_docs[package_name] == nil then
-		local docs = vim.fn.systemlist("go doc --all " .. package_name)
-		if vim.v.shell_error ~= 0 then
-			return { "No documentation available for " .. package_name }
-		end
-
-		package_docs[package_name] = docs
-	end
-
-	return package_docs[package_name]
 end
 
 -- Show documentation in new buffer
-function M.show_documentation(package_name)
-	local doc = M.get_documentation(package_name)
+--- @param adapter GoDocAdapter
+--- @param item string
+function M.show_documentation(adapter, item)
+	local content = adapter.get_content(item)
 
 	-- Create new buffer
 	local buf = vim.api.nvim_create_buf(false, true)
-	vim.api.nvim_buf_set_lines(buf, 0, -1, false, doc)
+	vim.api.nvim_buf_set_lines(buf, 0, -1, false, content)
 
 	-- Set buffer options
 	vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
-	vim.api.nvim_set_option_value("filetype", "godoc", { buf = buf })
+	vim.api.nvim_set_option_value("filetype", adapter.get_syntax_info().filetype, { buf = buf })
 
 	-- Open window based on config
-	if M.config.window.type == "split" then
+	if M.defaults.window.type == "split" then
 		vim.cmd("split")
-	elseif M.config.window.type == "vsplit" then
+	elseif M.defaults.window.type == "vsplit" then
 		vim.cmd("vsplit")
-	else -- floating
-		-- TODO: Implement floating window?
+	else
+		vim.notify("Invalid window type: " .. M.defaults.window.type, vim.log.levels.ERROR)
 	end
 
 	vim.api.nvim_set_current_buf(buf)
-	-- vim.cmd("file " .. package_name .. ".godoc")
 
 	-- Set up keymaps for the documentation window
 	local opts = { noremap = true, silent = true, buffer = buf }

--- a/lua/godoc/pickers/init.lua
+++ b/lua/godoc/pickers/init.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+--- @type table<string, GoDocPicker>
+local pickers = {
+	native = require("godoc.pickers.native"),
+	telescope = require("godoc.pickers.telescope"),
+	snacks = require("godoc.pickers.snacks"),
+	mini = require("godoc.pickers.mini"),
+}
+
+--- Get a picker implementation
+--- @param picker_type string
+--- @return GoDocPicker?
+function M.get_picker(picker_type)
+	return pickers[picker_type]
+end
+
+return M

--- a/lua/godoc/pickers/mini.lua
+++ b/lua/godoc/pickers/mini.lua
@@ -1,0 +1,35 @@
+--- @class MiniPicker: GoDocPicker
+local M = {}
+
+--- @param adapter GoDocAdapter
+--- @param config GoDocConfig
+--- @param callback fun(choice: string|nil)
+function M.show(adapter, config, callback)
+	local minipick = require("mini.pick")
+
+	-- Create picker configuration
+	local opts = {
+		source = {
+			items = adapter.get_items(),
+			name = "Select item",
+			preview = function(buf_id, item)
+				vim.notify(vim.inspect(buf_id))
+				local content = adapter.get_content(item)
+				local syntax_info = adapter.get_syntax_info()
+				vim.api.nvim_buf_set_lines(buf_id, 0, -1, false, content)
+				vim.api.nvim_set_option_value("filetype", syntax_info.filetype, { buf = buf_id })
+			end,
+			choose = function(item)
+				callback(item)
+			end,
+		},
+	}
+
+	if config.picker.mini then
+		opts = vim.tbl_deep_extend("force", opts, config.picker.mini)
+	end
+
+	minipick.start(opts)
+end
+
+return M

--- a/lua/godoc/pickers/native.lua
+++ b/lua/godoc/pickers/native.lua
@@ -1,0 +1,22 @@
+local M = {}
+
+--- @param adapter GoDocAdapter
+--- @param config GoDocConfig
+--- @param callback fun(choice: string|nil)
+function M.show(adapter, config, callback)
+	-- Create picker configuration
+	local opts = {
+		prompt = "Select item",
+		format_item = function(item)
+			return item
+		end,
+	}
+
+	if config.picker.native then
+		opts = vim.tbl_deep_extend("force", opts, config.picker.native)
+	end
+
+	vim.ui.select(adapter.get_items(), opts, callback)
+end
+
+return M

--- a/lua/godoc/pickers/snacks.lua
+++ b/lua/godoc/pickers/snacks.lua
@@ -1,0 +1,56 @@
+--- @class SnacksPicker: GoDocPicker
+local M = {}
+
+--- @param adapter GoDocAdapter
+--- @param config GoDocConfig
+--- @param callback fun(choice: string|nil)
+function M.show(adapter, config, callback)
+	local snacks = require("snacks")
+
+	local function create_items()
+		local items = {}
+		for _, item_name in ipairs(adapter.get_items()) do
+			table.insert(items, {
+				text = item_name,
+				item_name = item_name,
+			})
+		end
+		return items
+	end
+
+	local syntax_info = adapter.get_syntax_info()
+
+	-- Create picker configuration
+	--- @type snacks.picker.Config
+	local opts = {
+		finder = create_items,
+		format = "text",
+		title = "Select item",
+		preview = function(ctx)
+			if ctx.item then
+				local content = adapter.get_content(ctx.item.item_name)
+				ctx.preview:set_lines(content)
+				ctx.preview:highlight({ ft = syntax_info.filetype })
+			else
+				ctx.preview:reset()
+			end
+		end or nil,
+		actions = {
+			confirm = function(picker, item)
+				if item then
+					snacks.picker.actions.close(picker)
+					callback(item.item_name)
+				end
+			end,
+		},
+	}
+
+	-- Merge with global picker config if it exists
+	if config.picker.snacks then
+		opts = vim.tbl_deep_extend("force", opts, config.picker.snacks)
+	end
+
+	snacks.picker.pick(opts)
+end
+
+return M

--- a/lua/godoc/pickers/telescope.lua
+++ b/lua/godoc/pickers/telescope.lua
@@ -1,0 +1,80 @@
+--- @class TelescopePicker: GoDocPicker
+local M = {}
+
+--- @param adapter GoDocAdapter
+--- @param config GoDocConfig
+--- @param callback fun(choice: string|nil)
+function M.show(adapter, config, callback)
+	local action_state = require("telescope.actions.state")
+	local finders = require("telescope.finders")
+	local pickers = require("telescope.pickers")
+	local previewers = require("telescope.previewers")
+	local conf = require("telescope.config").values
+
+	-- Create custom previewer
+	local package_previewer = previewers.new_buffer_previewer({
+		title = "Contents",
+		get_buffer_by_name = function(_, entry)
+			return entry.value
+		end,
+		define_preview = function(self, entry)
+			local docs = adapter.get_content(entry.value)
+			vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, docs)
+			local syntax_info = adapter.get_syntax_info()
+			vim.api.nvim_set_option_value("filetype", syntax_info.filetype, { buf = self.state.bufnr })
+		end,
+	})
+
+	local function on_package_select(prompt_bufnr)
+		local selection = action_state.get_selected_entry()
+		if selection then
+			callback(selection.value)
+		end
+	end
+
+	-- Get items from adapter
+	local items = adapter.get_items()
+	local formatted_items = {}
+	for _, item in ipairs(items) do
+		table.insert(formatted_items, {
+			value = item,
+			display = item,
+			ordinal = item,
+		})
+	end
+
+	-- Create picker configuration
+	local opts = {
+		finder = finders.new_table({
+			results = formatted_items,
+			entry_maker = function(entry)
+				return {
+					display = entry.display,
+					value = entry.value,
+					ordinal = entry.ordinal,
+				}
+			end,
+		}),
+		sorter = conf.generic_sorter(),
+		previewer = package_previewer,
+		attach_mappings = function(_, map)
+			map("i", "<CR>", function(prompt_bufnr)
+				vim.cmd("stopinsert")
+				on_package_select(prompt_bufnr)
+			end)
+			map("n", "<CR>", function(prompt_bufnr)
+				on_package_select(prompt_bufnr)
+			end)
+			return true
+		end,
+	}
+
+	-- Merge with global picker config if it exists
+	if config.picker.telescope then
+		opts = vim.tbl_deep_extend("force", opts, config.picker.telescope)
+	end
+
+	pickers.new(opts, {}):find()
+end
+
+return M

--- a/lua/godoc/types.lua
+++ b/lua/godoc/types.lua
@@ -1,0 +1,56 @@
+--- @class GoDocConfig
+--- @field adapters GoDocAdapterConfig[] List of adapter configurations
+--- @field window GoDocWindowConfig Window configuration
+--- @field picker GoDocPickerConfig Picker configuration
+
+--- @class GoDocAdapter
+--- @field command string The vim command name to register
+--- @field get_items fun(): string[] Function that returns a list of available items
+--- @field get_content fun(choice: string): string[] Function that returns the content
+--- @field get_syntax_info fun(): GoDocSyntaxInfo Function that returns syntax info
+--- @field health? fun(): GoDocHealthCheck[] Optional health check function
+
+--- @class GoDocAdapterOpts
+--- @field command? string Override the command name
+--- @field get_items? fun(): string[] Override the get_items function
+--- @field get_content? fun(choice: string): string[] Override the get_content function
+--- @field get_syntax_info? fun(): GoDocSyntaxInfo Override the get_syntax_info function
+--- @field health? fun(): GoDocHealthCheck[] Override the health check function
+--- @field [string] any Other adapter-specific options
+
+--- @class GoDocBuiltinAdapter
+--- @field name string The name of the built-in adapter to extend
+--- @field opts? GoDocAdapterOpts Configuration options for the built-in adapter
+
+--- @class GoDocUserAdapter: GoDocAdapter
+--- @field name? nil Must not have a name field
+
+--- @class GoDocThirdPartyAdapter
+--- @field setup fun(): GoDocAdapter Function that returns the base adapter
+--- @field opts? GoDocAdapterOpts Options to override the returned adapter
+
+--- @alias GoDocAdapterConfig GoDocBuiltinAdapter|GoDocUserAdapter|GoDocThirdPartyAdapter
+
+--- @class GoDocHealthCheck
+--- @field ok boolean Whether the check passed
+--- @field message string Message describing the check result
+--- @field optional? boolean Whether this check is optional (default: false)
+
+--- @class GoDocSyntaxInfo
+--- @field filetype string The filetype to set for the documentation buffer
+--- @field language string The treesitter language to use
+
+--- @class GoDocWindowConfig
+--- @field type "split"|"vsplit" The type of window to open
+
+--- @class GoDocPicker
+--- @field show fun(adapter: GoDocAdapter, user_config: GoDocConfig, callback: fun(choice: string|nil)) Shows the picker UI with items from adapter
+
+--- @class GoDocPickerConfig
+--- @field type "native"|"telescope"|"snacks"|"mini" The type of picker to use
+--- @field native? table Options for native picker
+--- @field telescope? table Options for telescope picker
+--- @field snacks? table Options for snacks picker
+--- @field mini? table Options for mini.pick picker
+
+return {}


### PR DESCRIPTION
### Why this change?

It turns out [a lot of people](https://www.reddit.com/r/neovim/comments/1ivfg8x/godocnvim_golang_docs_inside_neovim/) want to tap into this project's main functionality; showing language docs inside Neovim, but for another language.

### What was changed?

The entire project has been rewritten, refactored and enables extensibility:

- Third-party adapters
- User-specified adapters
- Bundled adapters (Go is the one I've bundled initially)

### Example configs

```lua
{
    "fredrikaverpil/godoc.nvim",
    branch = "2.0-rewrite",
    dependencies = {
        { "nvim-telescope/telescope.nvim" }, -- optional
        { "folke/snacks.nvim" }, -- optional
        {
            "nvim-treesitter/nvim-treesitter",
            opts = {
              ensure_installed = { "go" },
            },
        },
    },
    build = "go install github.com/lotusirous/gostdsym/stdsym@latest", -- optional
    cmd = { "GoDoc" },
    opts = {
		{
			picker = {
				type = "snacks",
			},
		    adapters = {
		        -- Built-in adapter
		        "go",
		
		        -- Custom adapter defined inline
		        {
		            command = "RustDoc",
		            get_items = function()
		                return vim.fn.systemlist("rustup doc --list")
		            end,
		            get_content = function(choice)
		                return vim.fn.systemlist("rustup doc " .. choice)
		            end,
		            get_syntax_info = function()
		                return {
		                    filetype = "rustdoc",
		                    language = "rust"
		                }
		            end
		        }
		    }
		}
	},
}
```

### To do

- [x] Adapter interface
- [x] Bundled adapters
- [x] User-specified adapters
- [x] Third-party adapters
- [x] Facility for implementing different kinds of pickers
- [x] Native `vim.ui.select` picker
- [x] Telescope picker
- [x] Snacks picker
- [x] Ability to provide custom opts to the picker
	- [x] From user-specified opts
	- [x] From adapter-specified opts
- [x] Go doc adapter
- [x] `:checkhealth` for each adapter
- [x] Updated README
- [ ] Tests ?!!!

