### PR TITLE
feat: goto definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ _Screenshot is showing the Snacks picker._
 
 ## Features
 
-- Browse and search Go standard library packages and project packages.
+- Search and browse docs for Go standard library packages and project packages.
+- Go to definition capability.
 - Syntax highlighting for Go documentation.
 - Optionally leverage [`stdsym`](https://github.com/lotusirous/gostdsym) for
   symbols searching.
@@ -89,6 +90,8 @@ provided:
 - `:GoDoc` - Open picker and search packages.
 - `:GoDoc <package>` - Directly open documentation for the specified package or
   symbol.
+- In Normal mode, press `gd` to go package definition (only supported by Snacks
+  and Telescope pickers). For fzf-lua, the keymap is `ctrl-s`.
 
 > [!WARNING]
 >
@@ -287,6 +290,7 @@ All adapters must implement the interface of `GoDocAdapter`:
 --- @field get_items fun(): string[] Function that returns a list of available items
 --- @field get_content fun(choice: string): string[] Function that returns the content
 --- @field get_syntax_info fun(): GoDocSyntaxInfo Function that returns syntax info
+--- @field goto_definition? fun(choice: string, picker_gotodef_fun: fun()?): nil Function that returns the definition location
 --- @field health? fun(): GoDocHealthCheck[] Optional health check function
 ```
 
@@ -299,6 +303,7 @@ The `opts` which can be passed into an adapter (by the user) is implemented by
 --- @field get_items? fun(): string[] Override the get_items function
 --- @field get_content? fun(choice: string): string[] Override the get_content function
 --- @field get_syntax_info? fun(): GoDocSyntaxInfo Override the get_syntax_info function
+--- @field goto_definition? fun(choice: string, picker_gotodef_fun: fun()?): nil Override the get_definition function
 --- @field health? fun(): GoDocHealthCheck[] Override the health check function
 --- @field [string] any Other adapter-specific options
 ```

--- a/lua/godoc/adapters/go.lua
+++ b/lua/godoc/adapters/go.lua
@@ -86,14 +86,13 @@ end
 
 --- @param package string
 --- @param picker_gotodef_fun fun() | nil
---- @return boolean
 local function goto_package_definition(package, picker_gotodef_fun)
 	if not picker_gotodef_fun then
 		vim.notify(
 			"Picker does not implement a function which can be used for showing definitions",
 			vim.log.levels.WARN
 		)
-		return false
+		return
 	end
 
 	-- Create temp file instead of just in-memory buffer
@@ -124,8 +123,6 @@ import "%s"
 	vim.wait(100)
 
 	picker_gotodef_fun()
-
-	return true
 end
 
 local function health()

--- a/lua/godoc/adapters/go.lua
+++ b/lua/godoc/adapters/go.lua
@@ -188,6 +188,7 @@ local function goto_definition(item, picker_gotodef_fun)
 	--	TODO: would be nice to do this more reliably, and not based on a timeout
 	vim.defer_fn(function()
 		vim.api.nvim_win_close(window, true)
+		vim.api.nvim_buf_delete(buf, { force = true })
 		vim.fn.delete(tempfile)
 	end, 2000)
 end

--- a/lua/godoc/adapters/go.lua
+++ b/lua/godoc/adapters/go.lua
@@ -84,6 +84,19 @@ local function get_packages()
 	return all_packages
 end
 
+--- @param package string
+--- @return GoDocDefinition?
+local function get_package_definition(package)
+	-- TODO: get package entry point
+	local stdout = vim.fn.system("go list -f '{{.Dir}}' " .. package)
+	if vim.v.shell_error == 0 then
+		return {
+			filepath = vim.trim(stdout),
+			position = nil,
+		}
+	end
+end
+
 local function health()
 	--- @type GoDocHealthCheck[]
 	local checks = {}
@@ -210,6 +223,9 @@ function M.setup(opts)
 		end,
 		get_content = function(choice)
 			return vim.fn.systemlist("go doc -all " .. choice)
+		end,
+		get_definition = function(choice)
+			return get_package_definition(choice)
 		end,
 		get_syntax_info = function()
 			return {

--- a/lua/godoc/adapters/go.lua
+++ b/lua/godoc/adapters/go.lua
@@ -89,7 +89,10 @@ end
 --- @return boolean
 local function goto_package_definition(package, picker_gotodef_fun)
 	if not picker_gotodef_fun then
-		vim.notify("Picker does not implement 'lsp_definitions'", vim.log.levels.WARN)
+		vim.notify(
+			"Picker does not implement a function which can be used for showing definitions",
+			vim.log.levels.WARN
+		)
 		return false
 	end
 
@@ -258,8 +261,8 @@ function M.setup(opts)
 				language = "go",
 			}
 		end,
-		goto_definition = function(choice, lsp_definition_fun)
-			return goto_package_definition(choice, lsp_definition_fun)
+		goto_definition = function(choice, picker_gotodef_fun)
+			return goto_package_definition(choice, picker_gotodef_fun)
 		end,
 		health = health,
 	}

--- a/lua/godoc/adapters/go.lua
+++ b/lua/godoc/adapters/go.lua
@@ -96,14 +96,55 @@ local function goto_package_definition(package, picker_gotodef_fun)
 	end
 
 	-- write temp file
-	local content = {
-		"package main",
-		"",
-		'import "' .. package .. '"',
-	}
-	local tempdir = vim.fn.tempname()
-	vim.fn.mkdir(tempdir, "p")
-	local tempfile = tempdir .. "/temp.go"
+	local content = {}
+	local cursor_pos = {}
+	local is_symbol = package:find("%.") ~= nil
+	if is_symbol then
+		-- an import with symbol is passed, e.g. archive/tar.FileInfoNames
+		--
+		-- extract the import path (archive/tar)
+		local import_path = package:match("^(.-)%.")
+		-- extract the package name, which comes after the last slash (e.g. tar)
+		local package_name = import_path:match("([^/]+)$")
+		-- extract the symbol name, which comes after the last dot (e.g. FileInfoNames)
+		local symbol = package:match("([^%.]+)$")
+		-- the contents of the go file, which contains imports to the package and the symbol as well as the fmt package
+		local line = '  fmt.Printf("%v", ' .. package_name .. "." .. symbol .. ")"
+		content = {
+			"package main",
+			"",
+			"import (",
+			'  "' .. import_path .. '"',
+			'  "fmt"',
+			")",
+			"",
+			"func main() {",
+			line,
+			"}",
+		}
+		-- put the position/cursor on the symbol, e.g. on the 'F' of FileInfoNames
+		cursor_pos = { 9, line:find(symbol) + 1 }
+	else
+		-- a package name is passed, e.g. "archive/tar"
+		local line = 'import "' .. package .. '"'
+		content = {
+			"package main",
+			"",
+			line,
+		}
+		cursor_pos = { 3, line:find(package) + 1 }
+	end
+	vim.notify(vim.inspect(cursor_pos))
+	local now = os.time()
+	local filename = "godoc_" .. now .. ".go"
+	local tempfile = vim.fn.getcwd() .. "/" .. filename
+	local go_mod_filepath = vim.fn.findfile("go.mod", ".;")
+	local go_mod_dir = vim.fn.fnamemodify(go_mod_filepath, ":p:h")
+	if go_mod_dir == "" then
+		vim.notify("Failed to find go.mod file, can only gotodef on std lib", vim.log.levels.WARN)
+	else
+		tempfile = go_mod_dir .. "/" .. filename
+	end
 	vim.fn.writefile(content, tempfile)
 
 	-- create hidden window to run picker in
@@ -122,6 +163,9 @@ local function goto_package_definition(package, picker_gotodef_fun)
 	-- get ahold of the created buffer
 	local buf = vim.api.nvim_win_get_buf(window)
 
+	-- disable diagnostics for the buffer
+	vim.diagnostic.enable(false, { bufnr = buf })
+
 	-- wait until LSP has attached, can be queried and returns a client_id
 	local client_id = nil
 	local maxretries = 50
@@ -136,15 +180,16 @@ local function goto_package_definition(package, picker_gotodef_fun)
 
 	-- execute in window
 	vim.api.nvim_win_call(window, function()
-		vim.api.nvim_win_set_cursor(0, { 3, 8 }) -- position cursor over package name
+		vim.api.nvim_win_set_cursor(0, cursor_pos) -- position cursor over package name
 		picker_gotodef_fun() -- run picker's goto definition function
 	end)
 
-	-- close hidden window and delete temp file, but wait so that picker has time to finish
+	--	close hidden window and delete temp file, but wait so that picker has time to finish
+	--	TODO: would be nice to do this more reliably, and not based on a timeout
 	vim.defer_fn(function()
 		vim.api.nvim_win_close(window, true)
 		vim.fn.delete(tempfile)
-	end, 500)
+	end, 2000)
 end
 
 local function health()

--- a/lua/godoc/adapters/go.lua
+++ b/lua/godoc/adapters/go.lua
@@ -138,7 +138,7 @@ local function goto_definition(item, picker_gotodef_fun)
 	local now = os.time()
 	local filename = "godoc_" .. now .. ".go"
 	local tempfile = vim.fn.getcwd() .. "/" .. filename
-	local go_mod_filepath = vim.fn.findfile("go.mod", ".;")
+	local go_mod_filepath = vim.fn.findfile("go.mod", vim.fn.getcwd() .. ";")
 	local go_mod_dir = vim.fn.fnamemodify(go_mod_filepath, ":p:h")
 	if go_mod_dir == "" then
 		vim.notify("Failed to find go.mod file, can only gotodef on std lib", vim.log.levels.WARN)

--- a/lua/godoc/adapters/go.lua
+++ b/lua/godoc/adapters/go.lua
@@ -130,7 +130,7 @@ local function goto_definition(item, picker_gotodef_fun)
 		content = {
 			"package main",
 			"",
-			line = 'import "' .. item .. '"',
+			'import "' .. item .. '"',
 		}
 		cursor_pos = { 3, 9 }
 	end

--- a/lua/godoc/adapters/go.lua
+++ b/lua/godoc/adapters/go.lua
@@ -134,7 +134,6 @@ local function goto_package_definition(package, picker_gotodef_fun)
 		}
 		cursor_pos = { 3, line:find(package) + 1 }
 	end
-	vim.notify(vim.inspect(cursor_pos))
 	local now = os.time()
 	local filename = "godoc_" .. now .. ".go"
 	local tempfile = vim.fn.getcwd() .. "/" .. filename

--- a/lua/godoc/adapters/go.lua
+++ b/lua/godoc/adapters/go.lua
@@ -98,7 +98,7 @@ local function goto_definition(item, picker_gotodef_fun)
 	-- write temp file
 	local content = {}
 	local cursor_pos = {}
-	-- check if the package contains a symbol
+	-- check if the chosen item contains a symbol
 	local is_symbol = string.match(item, "%.%a[%w_]*$") ~= nil
 	if is_symbol then
 		-- an import with symbol is passed, e.g. archive/tar.FileInfoNames
@@ -127,13 +127,12 @@ local function goto_definition(item, picker_gotodef_fun)
 		cursor_pos = { 9, line:find(symbol) + 1 }
 	else
 		-- a package name is passed, e.g. "archive/tar"
-		local line = 'import "' .. item .. '"'
 		content = {
 			"package main",
 			"",
-			line,
+			line = 'import "' .. item .. '"',
 		}
-		cursor_pos = { 3, line:find(item) + 1 }
+		cursor_pos = { 3, 9 }
 	end
 	local now = os.time()
 	local filename = "godoc_" .. now .. ".go"

--- a/lua/godoc/adapters/go.lua
+++ b/lua/godoc/adapters/go.lua
@@ -102,6 +102,10 @@ local function goto_package_definition(package, picker_gotodef_fun)
 
 	-- Write content to the actual file
 	local file = io.open(temp_file, "w")
+  if not file then
+    vim.notify("Failed to create temporary file", vim.log.levels.ERROR)
+    return
+end
 	file:write(string.format(
 		[[
 package main

--- a/lua/godoc/adapters/go.lua
+++ b/lua/godoc/adapters/go.lua
@@ -85,7 +85,7 @@ local function get_packages()
 end
 
 --- @param package string
---- @param picker_gotodef_fun fun() | nil
+--- @param picker_gotodef_fun fun()?
 local function goto_package_definition(package, picker_gotodef_fun)
 	if not picker_gotodef_fun then
 		vim.notify(

--- a/lua/godoc/adapters/init.lua
+++ b/lua/godoc/adapters/init.lua
@@ -43,6 +43,7 @@ function M.validate_adapter(adapter)
 		{ name = "command", type = "string" },
 		{ name = "get_items", type = "function" },
 		{ name = "get_content", type = "function" },
+    { name = "get_definition", type = "function" },
 		{ name = "get_syntax_info", type = "function" },
 	}
 
@@ -69,6 +70,7 @@ function M.override_adapter(default_adapter, user_opts)
 		command = user_opts.command or default_adapter.command,
 		get_items = user_opts.get_items or default_adapter.get_items,
 		get_content = user_opts.get_content or default_adapter.get_content,
+		get_definition = user_opts.get_definition or default_adapter.get_definition,
 		get_syntax_info = user_opts.get_syntax_info or default_adapter.get_syntax_info,
 		health = user_opts.health or default_adapter.health,
 	}

--- a/lua/godoc/adapters/init.lua
+++ b/lua/godoc/adapters/init.lua
@@ -43,8 +43,8 @@ function M.validate_adapter(adapter)
 		{ name = "command", type = "string" },
 		{ name = "get_items", type = "function" },
 		{ name = "get_content", type = "function" },
-		{ name = "get_definition", type = "function" },
 		{ name = "get_syntax_info", type = "function" },
+		{ name = "goto_definition", type = "function" },
 	}
 
 	for _, field in ipairs(required_fields) do
@@ -70,8 +70,8 @@ function M.override_adapter(default_adapter, user_opts)
 		command = user_opts.command or default_adapter.command,
 		get_items = user_opts.get_items or default_adapter.get_items,
 		get_content = user_opts.get_content or default_adapter.get_content,
-		get_definition = user_opts.get_definition or default_adapter.get_definition,
 		get_syntax_info = user_opts.get_syntax_info or default_adapter.get_syntax_info,
+		goto_definition = user_opts.goto_definition or default_adapter.goto_definition,
 		health = user_opts.health or default_adapter.health,
 	}
 end

--- a/lua/godoc/adapters/init.lua
+++ b/lua/godoc/adapters/init.lua
@@ -43,7 +43,7 @@ function M.validate_adapter(adapter)
 		{ name = "command", type = "string" },
 		{ name = "get_items", type = "function" },
 		{ name = "get_content", type = "function" },
-    { name = "get_definition", type = "function" },
+		{ name = "get_definition", type = "function" },
 		{ name = "get_syntax_info", type = "function" },
 	}
 

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -154,16 +154,12 @@ function M.show_documentation(adapter, item)
 	vim.keymap.set("n", "<Esc>", ":close<CR>", opts)
 end
 
---- Open source code in new buffer
+--- Go to definition on chosen item
 --- @param adapter GoDocAdapter
 --- @param item string
 --- @param picker_gotodef_fun fun()?
 function M.goto_definition(adapter, item, picker_gotodef_fun)
-	local definition = adapter.goto_definition(item, picker_gotodef_fun)
-	if not definition then
-		vim.notify("No definition found for: " .. item, vim.log.levels.WARN)
-		return
-	end
+	adapter.goto_definition(item, picker_gotodef_fun)
 end
 
 return M

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -158,6 +158,7 @@ end
 --- @param adapter GoDocAdapter
 --- @param item string
 --- @param picker_gotodef_fun fun()?
+--- @return nil
 function M.goto_definition(adapter, item, picker_gotodef_fun)
 	adapter.goto_definition(item, picker_gotodef_fun)
 end

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -109,7 +109,7 @@ function M.setup(opts)
 						if data.type == "show_documentation" then
 							M.show_documentation(adapter, data.choice)
 						elseif data.type == "goto_definition" then
-							M.goto_definition(adapter, data.choice)
+							M.goto_definition(adapter, picker, data.choice)
 						end
 					end
 				end)
@@ -156,13 +156,14 @@ end
 
 --- Open source code in new buffer
 --- @param adapter GoDocAdapter
+--- @param picker GoDocPicker
 --- @param item string
-function M.goto_definition(adapter, item)
+function M.goto_definition(adapter, picker, item)
 	if not adapter.get_definition then
 		return
 	end
 
-	local definition = adapter.get_definition(item)
+	local definition = adapter.get_definition(item, picker)
 	if not definition then
 		vim.notify("No definition found for: " .. item, vim.log.levels.WARN)
 		return

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -109,7 +109,7 @@ function M.setup(opts)
 						if data.type == "show_documentation" then
 							M.show_documentation(adapter, data.choice)
 						elseif data.type == "goto_definition" then
-							M.goto_definition(adapter, picker, data.choice)
+							M.goto_definition(adapter, data.choice, picker.goto_definition)
 						end
 					end
 				end)
@@ -156,24 +156,13 @@ end
 
 --- Open source code in new buffer
 --- @param adapter GoDocAdapter
---- @param picker GoDocPicker
 --- @param item string
-function M.goto_definition(adapter, picker, item)
-	if not adapter.get_definition then
-		return
-	end
-
-	local definition = adapter.get_definition(item, picker)
+--- @param picker_gotodef_fun fun()?
+function M.goto_definition(adapter, item, picker_gotodef_fun)
+	local definition = adapter.goto_definition(item, picker_gotodef_fun)
 	if not definition then
 		vim.notify("No definition found for: " .. item, vim.log.levels.WARN)
 		return
-	end
-
-	open_window(M.config.window.type)
-
-	vim.cmd("silent! e " .. vim.fn.fnameescape(definition.filepath))
-	if definition.position then
-		vim.api.nvim_win_set_cursor(0, definition.position)
 	end
 end
 

--- a/lua/godoc/pickers/fzf_lua.lua
+++ b/lua/godoc/pickers/fzf_lua.lua
@@ -1,14 +1,11 @@
 --- @class Fzflua: GoDocPicker
 local M = {}
 
-M.lsp_definitions = nil
-
 --- @param adapter GoDocAdapter
 --- @param config GoDocConfig
 --- @param callback fun(choice: GoDocCallbackData)
 function M.show(adapter, config, callback)
 	local core = require("fzf-lua.core")
-	M.lsp_definitions = require("fzf-lua").lsp_definitions
 	local opts = {
 		prompt = "Select item",
 		fn_transform = function() end,

--- a/lua/godoc/pickers/fzf_lua.lua
+++ b/lua/godoc/pickers/fzf_lua.lua
@@ -28,6 +28,8 @@ function M.show(adapter, config, callback)
 	core.fzf_exec(adapter.get_items(), opts)
 end
 
-M.goto_definition = nil
+M.goto_definition = function()
+	return require("fzf-lua").lsp_definitions()
+end
 
 return M

--- a/lua/godoc/pickers/fzf_lua.lua
+++ b/lua/godoc/pickers/fzf_lua.lua
@@ -1,13 +1,14 @@
 --- @class Fzflua: GoDocPicker
 local M = {}
 
-M.lsp_definitions = require("fzf-lua").lsp_definitions
+M.lsp_definitions = nil
 
 --- @param adapter GoDocAdapter
 --- @param config GoDocConfig
 --- @param callback fun(choice: GoDocCallbackData)
 function M.show(adapter, config, callback)
 	local core = require("fzf-lua.core")
+	M.lsp_definitions = require("fzf-lua").lsp_definitions
 	local opts = {
 		prompt = "Select item",
 		fn_transform = function() end,
@@ -29,5 +30,7 @@ function M.show(adapter, config, callback)
 
 	core.fzf_exec(adapter.get_items(), opts)
 end
+
+M.goto_definition = nil
 
 return M

--- a/lua/godoc/pickers/fzf_lua.lua
+++ b/lua/godoc/pickers/fzf_lua.lua
@@ -3,7 +3,7 @@ local M = {}
 
 --- @param adapter GoDocAdapter
 --- @param config GoDocConfig
---- @param callback fun(choice: string|nil)
+--- @param callback fun(choice: GoDocCallbackData)
 function M.show(adapter, config, callback)
 	local core = require("fzf-lua.core")
 	local opts = {
@@ -12,7 +12,11 @@ function M.show(adapter, config, callback)
 		debug = false,
 		actions = {
 			["default"] = function(selected, _)
-				callback(table.concat(selected, ""))
+				callback({ type = "show_documentation", choice = table.concat(selected, "") })
+			end,
+			-- TODO: fzf lua doesn't accept 'gd' as a keymap
+			["ctrl-s"] = function(selected, _)
+				callback({ type = "goto_definition", choice = table.concat(selected, "") })
 			end,
 		},
 	}

--- a/lua/godoc/pickers/fzf_lua.lua
+++ b/lua/godoc/pickers/fzf_lua.lua
@@ -28,8 +28,9 @@ function M.show(adapter, config, callback)
 	core.fzf_exec(adapter.get_items(), opts)
 end
 
+--- @return nil
 M.goto_definition = function()
-	return require("fzf-lua").lsp_definitions()
+	require("fzf-lua").lsp_definitions()
 end
 
 return M

--- a/lua/godoc/pickers/fzf_lua.lua
+++ b/lua/godoc/pickers/fzf_lua.lua
@@ -1,6 +1,8 @@
 --- @class Fzflua: GoDocPicker
 local M = {}
 
+M.lsp_definitions = require("fzf-lua").lsp_definitions
+
 --- @param adapter GoDocAdapter
 --- @param config GoDocConfig
 --- @param callback fun(choice: GoDocCallbackData)

--- a/lua/godoc/pickers/mini.lua
+++ b/lua/godoc/pickers/mini.lua
@@ -3,7 +3,7 @@ local M = {}
 
 --- @param adapter GoDocAdapter
 --- @param config GoDocConfig
---- @param callback fun(choice: string|nil)
+--- @param callback fun(choice: GoDocCallbackData)
 function M.show(adapter, config, callback)
 	local minipick = require("mini.pick")
 
@@ -20,7 +20,7 @@ function M.show(adapter, config, callback)
 				vim.api.nvim_set_option_value("filetype", syntax_info.filetype, { buf = buf_id })
 			end,
 			choose = function(item)
-				callback(item)
+				callback({ type = "show_documentation", choice = item })
 			end,
 		},
 	}

--- a/lua/godoc/pickers/mini.lua
+++ b/lua/godoc/pickers/mini.lua
@@ -32,4 +32,6 @@ function M.show(adapter, config, callback)
 	minipick.start(opts)
 end
 
+M.goto_definition = nil
+
 return M

--- a/lua/godoc/pickers/mini.lua
+++ b/lua/godoc/pickers/mini.lua
@@ -32,6 +32,7 @@ function M.show(adapter, config, callback)
 	minipick.start(opts)
 end
 
+-- NOTE: goto definition is not supported in mini picker
 M.goto_definition = nil
 
 return M

--- a/lua/godoc/pickers/native.lua
+++ b/lua/godoc/pickers/native.lua
@@ -21,6 +21,7 @@ function M.show(adapter, config, callback)
 	end)
 end
 
+-- NOTE: goto definition is not supported in native picker
 M.goto_definition = nil
 
 return M

--- a/lua/godoc/pickers/native.lua
+++ b/lua/godoc/pickers/native.lua
@@ -21,4 +21,6 @@ function M.show(adapter, config, callback)
 	end)
 end
 
+M.goto_definition = nil
+
 return M

--- a/lua/godoc/pickers/native.lua
+++ b/lua/godoc/pickers/native.lua
@@ -2,7 +2,7 @@ local M = {}
 
 --- @param adapter GoDocAdapter
 --- @param config GoDocConfig
---- @param callback fun(choice: string|nil)
+--- @param callback fun(choice: GoDocCallbackData)
 function M.show(adapter, config, callback)
 	-- Create picker configuration
 	local opts = {
@@ -16,7 +16,9 @@ function M.show(adapter, config, callback)
 		opts = vim.tbl_deep_extend("force", opts, config.picker.native)
 	end
 
-	vim.ui.select(adapter.get_items(), opts, callback)
+	vim.ui.select(adapter.get_items(), opts, function(choice)
+		callback({ type = "show_documentation", choice = choice })
+	end)
 end
 
 return M

--- a/lua/godoc/pickers/snacks.lua
+++ b/lua/godoc/pickers/snacks.lua
@@ -1,6 +1,8 @@
 --- @class SnacksPicker: GoDocPicker
 local M = {}
 
+M.lsp_definitions = require("snacks").picker.lsp_definitions
+
 --- @param adapter GoDocAdapter
 --- @param config GoDocConfig
 --- @param callback fun(data: GoDocCallbackData)

--- a/lua/godoc/pickers/snacks.lua
+++ b/lua/godoc/pickers/snacks.lua
@@ -3,7 +3,7 @@ local M = {}
 
 --- @param adapter GoDocAdapter
 --- @param config GoDocConfig
---- @param callback fun(choice: string|nil)
+--- @param callback fun(data: GoDocCallbackData)
 function M.show(adapter, config, callback)
 	local snacks = require("snacks")
 
@@ -35,11 +35,27 @@ function M.show(adapter, config, callback)
 				ctx.preview:reset()
 			end
 		end or nil,
+		win = {
+			input = {
+				keys = {
+					["gd"] = {
+						"goto_definition",
+						mode = { "n" },
+					},
+				},
+			},
+		},
 		actions = {
 			confirm = function(picker, item)
 				if item then
 					snacks.picker.actions.close(picker)
-					callback(item.item_name)
+					callback({ type = "show_documentation", choice = item.item_name })
+				end
+			end,
+			goto_definition = function(picker, item)
+				if item then
+					snacks.picker.actions.close(picker)
+					callback({ type = "goto_definition", choice = item.item_name })
 				end
 			end,
 		},

--- a/lua/godoc/pickers/snacks.lua
+++ b/lua/godoc/pickers/snacks.lua
@@ -69,6 +69,7 @@ function M.show(adapter, config, callback)
 	snacks.picker.pick(opts)
 end
 
+--- @return nil
 function M.goto_definition()
 	require("snacks").picker.lsp_definitions()
 end

--- a/lua/godoc/pickers/snacks.lua
+++ b/lua/godoc/pickers/snacks.lua
@@ -1,8 +1,6 @@
 --- @class SnacksPicker: GoDocPicker
 local M = {}
 
-M.lsp_definitions = require("snacks").picker.lsp_definitions
-
 --- @param adapter GoDocAdapter
 --- @param config GoDocConfig
 --- @param callback fun(data: GoDocCallbackData)
@@ -69,6 +67,10 @@ function M.show(adapter, config, callback)
 	end
 
 	snacks.picker.pick(opts)
+end
+
+function M.goto_definition()
+	require("snacks").picker.lsp_definitions()
 end
 
 return M

--- a/lua/godoc/pickers/telescope.lua
+++ b/lua/godoc/pickers/telescope.lua
@@ -1,6 +1,8 @@
 --- @class TelescopePicker: GoDocPicker
 local M = {}
 
+M.lsp_definitions = require("telescope.builtin").lsp_definitions
+
 --- @param adapter GoDocAdapter
 --- @param config GoDocConfig
 --- @param callback fun(data: GoDocCallbackData)

--- a/lua/godoc/pickers/telescope.lua
+++ b/lua/godoc/pickers/telescope.lua
@@ -3,7 +3,7 @@ local M = {}
 
 --- @param adapter GoDocAdapter
 --- @param config GoDocConfig
---- @param callback fun(choice: string|nil)
+--- @param callback fun(data: GoDocCallbackData)
 function M.show(adapter, config, callback)
 	local action_state = require("telescope.actions.state")
 	local finders = require("telescope.finders")
@@ -28,7 +28,14 @@ function M.show(adapter, config, callback)
 	local function on_package_select(prompt_bufnr)
 		local selection = action_state.get_selected_entry()
 		if selection then
-			callback(selection.value)
+			callback({ type = "show_documentation", choice = selection.value })
+		end
+	end
+
+	local function on_goto_definition(prompt_bufnr)
+		local selection = action_state.get_selected_entry()
+		if selection then
+			callback({ type = "goto_definition", choice = selection.value })
 		end
 	end
 
@@ -64,6 +71,9 @@ function M.show(adapter, config, callback)
 			end)
 			map("n", "<CR>", function(prompt_bufnr)
 				on_package_select(prompt_bufnr)
+			end)
+			map("n", "gd", function(prompt_bufnr)
+				on_goto_definition(prompt_bufnr)
 			end)
 			return true
 		end,

--- a/lua/godoc/pickers/telescope.lua
+++ b/lua/godoc/pickers/telescope.lua
@@ -87,8 +87,9 @@ function M.show(adapter, config, callback)
 	pickers.new(opts, {}):find()
 end
 
+--- @return nil
 function M.goto_definition()
-	return require("telescope.builtin").lsp_definitions
+	require("telescope.builtin").lsp_definitions()
 end
 
 return M

--- a/lua/godoc/pickers/telescope.lua
+++ b/lua/godoc/pickers/telescope.lua
@@ -1,8 +1,6 @@
 --- @class TelescopePicker: GoDocPicker
 local M = {}
 
-M.lsp_definitions = require("telescope.builtin").lsp_definitions
-
 --- @param adapter GoDocAdapter
 --- @param config GoDocConfig
 --- @param callback fun(data: GoDocCallbackData)
@@ -87,6 +85,10 @@ function M.show(adapter, config, callback)
 	end
 
 	pickers.new(opts, {}):find()
+end
+
+function M.goto_definition()
+	return require("telescope.builtin").lsp_definitions
 end
 
 return M

--- a/lua/godoc/types.lua
+++ b/lua/godoc/types.lua
@@ -8,6 +8,7 @@
 --- @field get_items fun(): string[] Function that returns a list of available items
 --- @field get_content fun(choice: string): string[] Function that returns the content
 --- @field get_syntax_info fun(): GoDocSyntaxInfo Function that returns syntax info
+--- @field get_definition? fun(choice: string): GoDocDefinition Function that returns the definition location
 --- @field health? fun(): GoDocHealthCheck[] Optional health check function
 
 --- @class GoDocAdapterOpts
@@ -15,6 +16,7 @@
 --- @field get_items? fun(): string[] Override the get_items function
 --- @field get_content? fun(choice: string): string[] Override the get_content function
 --- @field get_syntax_info? fun(): GoDocSyntaxInfo Override the get_syntax_info function
+--- @field get_definition? fun(choice: string): GoDocDefinition Override the get_definition function
 --- @field health? fun(): GoDocHealthCheck[] Override the health check function
 --- @field [string] any Other adapter-specific options
 
@@ -40,11 +42,19 @@
 --- @field filetype string The filetype to set for the documentation buffer
 --- @field language string The treesitter language to use for syntax highlighting
 
+--- @class GoDocDefinition
+--- @field filepath string Path on filesystem to the source code
+--- @field position [number, number]? Position of definition in source (row, col)
+
 --- @class GoDocWindowConfig
 --- @field type "split"|"vsplit" The type of window to open
 
+--- @class GoDocCallbackData
+--- @field type "show_documentation" | "goto_definition"
+--- @field choice string?
+
 --- @class GoDocPicker
---- @field show fun(adapter: GoDocAdapter, user_config: GoDocConfig, callback: fun(choice: string|nil)) Shows the picker UI with items from adapter
+--- @field show fun(adapter: GoDocAdapter, user_config: GoDocConfig, callback: fun(data:GoDocCallbackData)) Shows the picker UI with items from adapter
 
 --- @class GoDocPickerConfig
 --- @field type "native"|"telescope"|"snacks"|"mini"|"fzf_lua" The type of picker to use

--- a/lua/godoc/types.lua
+++ b/lua/godoc/types.lua
@@ -8,7 +8,7 @@
 --- @field get_items fun(): string[] Function that returns a list of available items
 --- @field get_content fun(choice: string): string[] Function that returns the content
 --- @field get_syntax_info fun(): GoDocSyntaxInfo Function that returns syntax info
---- @field goto_definition? fun(choice: string, picker_gotodef_fun: fun()?) Function that returns the definition location
+--- @field goto_definition? fun(choice: string, picker_gotodef_fun: fun()?): nil Function that returns the definition location
 --- @field health? fun(): GoDocHealthCheck[] Optional health check function
 
 --- @class GoDocAdapterOpts
@@ -16,7 +16,7 @@
 --- @field get_items? fun(): string[] Override the get_items function
 --- @field get_content? fun(choice: string): string[] Override the get_content function
 --- @field get_syntax_info? fun(): GoDocSyntaxInfo Override the get_syntax_info function
---- @field goto_definition? fun(choice: string, picker_gotodef_fun: fun()?) Override the get_definition function
+--- @field goto_definition? fun(choice: string, picker_gotodef_fun: fun()?): nil Override the get_definition function
 --- @field health? fun(): GoDocHealthCheck[] Override the health check function
 --- @field [string] any Other adapter-specific options
 

--- a/lua/godoc/types.lua
+++ b/lua/godoc/types.lua
@@ -8,7 +8,7 @@
 --- @field get_items fun(): string[] Function that returns a list of available items
 --- @field get_content fun(choice: string): string[] Function that returns the content
 --- @field get_syntax_info fun(): GoDocSyntaxInfo Function that returns syntax info
---- @field get_definition? fun(choice: string): GoDocDefinition Function that returns the definition location
+--- @field get_definition? fun(choice: string, picker: GoDocPicker): GoDocDefinition Function that returns the definition location
 --- @field health? fun(): GoDocHealthCheck[] Optional health check function
 
 --- @class GoDocAdapterOpts
@@ -16,7 +16,7 @@
 --- @field get_items? fun(): string[] Override the get_items function
 --- @field get_content? fun(choice: string): string[] Override the get_content function
 --- @field get_syntax_info? fun(): GoDocSyntaxInfo Override the get_syntax_info function
---- @field get_definition? fun(choice: string): GoDocDefinition Override the get_definition function
+--- @field get_definition? fun(choice: string, picker: GoDocPicker): GoDocDefinition Override the get_definition function
 --- @field health? fun(): GoDocHealthCheck[] Override the health check function
 --- @field [string] any Other adapter-specific options
 
@@ -55,6 +55,7 @@
 
 --- @class GoDocPicker
 --- @field show fun(adapter: GoDocAdapter, user_config: GoDocConfig, callback: fun(data:GoDocCallbackData)) Shows the picker UI with items from adapter
+--- @field lsp_definitions fun()? Picker specific implementation of lsp_definitions
 
 --- @class GoDocPickerConfig
 --- @field type "native"|"telescope"|"snacks"|"mini"|"fzf_lua" The type of picker to use

--- a/lua/godoc/types.lua
+++ b/lua/godoc/types.lua
@@ -8,7 +8,7 @@
 --- @field get_items fun(): string[] Function that returns a list of available items
 --- @field get_content fun(choice: string): string[] Function that returns the content
 --- @field get_syntax_info fun(): GoDocSyntaxInfo Function that returns syntax info
---- @field get_definition? fun(choice: string, picker: GoDocPicker): GoDocDefinition Function that returns the definition location
+--- @field goto_definition? fun(choice: string, picker_gotodef_fun: fun()?): boolean Function that returns the definition location
 --- @field health? fun(): GoDocHealthCheck[] Optional health check function
 
 --- @class GoDocAdapterOpts
@@ -16,7 +16,7 @@
 --- @field get_items? fun(): string[] Override the get_items function
 --- @field get_content? fun(choice: string): string[] Override the get_content function
 --- @field get_syntax_info? fun(): GoDocSyntaxInfo Override the get_syntax_info function
---- @field get_definition? fun(choice: string, picker: GoDocPicker): GoDocDefinition Override the get_definition function
+--- @field goto_definition? fun(choice: string, picker_gotodef_fun: fun()?): boolean Override the get_definition function
 --- @field health? fun(): GoDocHealthCheck[] Override the health check function
 --- @field [string] any Other adapter-specific options
 
@@ -42,10 +42,6 @@
 --- @field filetype string The filetype to set for the documentation buffer
 --- @field language string The treesitter language to use for syntax highlighting
 
---- @class GoDocDefinition
---- @field filepath string Path on filesystem to the source code
---- @field position [number, number]? Position of definition in source (row, col)
-
 --- @class GoDocWindowConfig
 --- @field type "split"|"vsplit" The type of window to open
 
@@ -55,8 +51,8 @@
 
 --- @class GoDocPicker
 --- @field show fun(adapter: GoDocAdapter, user_config: GoDocConfig, callback: fun(data:GoDocCallbackData)) Shows the picker UI with items from adapter
---- @field lsp_definitions fun()? Picker specific implementation of lsp_definitions
-
+--- @field goto_definition fun()? Picker-specific implementation of "go to definition"
+---
 --- @class GoDocPickerConfig
 --- @field type "native"|"telescope"|"snacks"|"mini"|"fzf_lua" The type of picker to use
 --- @field native? table Options for native picker

--- a/lua/godoc/types.lua
+++ b/lua/godoc/types.lua
@@ -8,7 +8,7 @@
 --- @field get_items fun(): string[] Function that returns a list of available items
 --- @field get_content fun(choice: string): string[] Function that returns the content
 --- @field get_syntax_info fun(): GoDocSyntaxInfo Function that returns syntax info
---- @field goto_definition? fun(choice: string, picker_gotodef_fun: fun()?): boolean Function that returns the definition location
+--- @field goto_definition? fun(choice: string, picker_gotodef_fun: fun()?) Function that returns the definition location
 --- @field health? fun(): GoDocHealthCheck[] Optional health check function
 
 --- @class GoDocAdapterOpts
@@ -16,7 +16,7 @@
 --- @field get_items? fun(): string[] Override the get_items function
 --- @field get_content? fun(choice: string): string[] Override the get_content function
 --- @field get_syntax_info? fun(): GoDocSyntaxInfo Override the get_syntax_info function
---- @field goto_definition? fun(choice: string, picker_gotodef_fun: fun()?): boolean Override the get_definition function
+--- @field goto_definition? fun(choice: string, picker_gotodef_fun: fun()?) Override the get_definition function
 --- @field health? fun(): GoDocHealthCheck[] Override the health check function
 --- @field [string] any Other adapter-specific options
 


### PR DESCRIPTION
Hey, I've been working on an adapter for the Nix language, but since much of it is undocumented I often find myself looking up the source code. Having a keymap to jump to it's definition would make this plugin perfect for me.

I've added the possibility for adapters to provide a path and the position in the file to jump to, though there are still some caveats:
- fzf-lua doesn't accept regular keymaps so I set it to `<C-s>` instead of `gd`
- I wasn't able to get it working for the native picker or mini.pick
- This doesn't make sense for all languages; for example, the implementation for the go adapter goes to the package directory instead of the actual implementation (omitting `get_definition` is also an option in this case)

This might be out of scope for this plugin, so just let me know if you'd be interested in including this, thanks :)