### PR TITLE
feat!: add support for tree-sitter-godoc parser

### DIFF
--- a/lua/godoc/adapters/go.lua
+++ b/lua/godoc/adapters/go.lua
@@ -302,7 +302,7 @@ function M.setup(opts)
 		get_syntax_info = function()
 			return {
 				filetype = "godoc",
-				language = "go",
+				language = "text",
 			}
 		end,
 		goto_definition = function(choice, picker_gotodef_fun)

--- a/queries/godoc/highlights.scm
+++ b/queries/godoc/highlights.scm
@@ -1,0 +1,6 @@
+; Treesitter highlight queries for godoc
+; These highlight structural elements (non-Go code regions)
+; Section headers (VARIABLES, FUNCTIONS, TYPES, CONSTANTS, etc.)
+(section_header) @label
+
+; Text lines remain unhighlighted (no capture = no highlighting)

--- a/queries/godoc/injections.scm
+++ b/queries/godoc/injections.scm
@@ -1,0 +1,41 @@
+; Treesitter injection queries for godoc
+; These inject the Go parser into specific regions of godoc output
+; Inject Go syntax into package lines
+((package_line) @injection.content
+  (#set! injection.language "go"))
+
+; Inject Go syntax into function lines
+((func_line) @injection.content
+  (#set! injection.language "go"))
+
+; Inject Go syntax into function blocks
+((func_block) @injection.content
+  (#set! injection.language "go"))
+
+; Inject Go syntax into type lines
+((type_line) @injection.content
+  (#set! injection.language "go"))
+
+; Inject Go syntax into type blocks
+((type_block) @injection.content
+  (#set! injection.language "go"))
+
+; Inject Go syntax into variable lines
+((var_line) @injection.content
+  (#set! injection.language "go"))
+
+; Inject Go syntax into variable blocks
+((var_block) @injection.content
+  (#set! injection.language "go"))
+
+; Inject Go syntax into constant lines
+((const_line) @injection.content
+  (#set! injection.language "go"))
+
+; Inject Go syntax into constant blocks
+((const_block) @injection.content
+  (#set! injection.language "go"))
+
+; Inject Go syntax into code blocks
+((code_block) @injection.content
+  (#set! injection.language "go"))


### PR DESCRIPTION
### Why?

The syntax highlighting of godoc documentation is messy/busy and quite difficult to read, regardless of which tree-sitter parser I'm trying this with.


I created [tree-sitter-godoc](https://github.com/fredrikaverpil/tree-sitter-godoc). Let's use that!

The parser doesn't syntax highlight Go code by itself but it detects where we expect Go code. Then we can use tree-sitter query injections to delegate syntax highlighting to the tree-sitter-go parser.


### What?

- Make default tree-sitter parser into `"text"`, which results in no syntax highlighting by default.
- Add optional support for `tree-sitter-godoc`.

### Screenshot


<img width="2081" height="1105" alt="image" src="https://github.com/user-attachments/assets/f9d0cedb-f53c-4cf4-a540-c27b8e38daa8" />

_Viewing docs with Tokyonight colorscheme and with both the tree-sitter-godoc and the tree-sitter-go parsers installed._