### PR TITLE
feat!: auto-register :GoDoc via plugin/godoc.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,12 +184,13 @@ require("godoc").setup({
 
 > [!NOTE]
 >
-> Calling `setup()` does not disturb the auto-registered `:GoDoc` unless your
-> config explicitly claims the `"GoDoc"` command name for a specific adapter —
-> in which case that adapter takes it over. This way you can rename the go
-> adapter's command (e.g., `command = "GoDocs"`) and still keep the built-in
-> `:GoDoc` running the defaults alongside, or reassign `:GoDoc` to a different
-> adapter entirely if that's what you want.
+> Once you call `setup()`, your configuration is the single source of truth for
+> which commands exist: the auto-registered `:GoDoc` is removed and the commands
+> are registered from your `adapters` list. If your config keeps the default
+> (the go adapter mapped to `"GoDoc"`), `:GoDoc` is re-registered as expected. If
+> you rename the go adapter's command (e.g., `command = "GoDocs"`), only `:GoDocs`
+> is registered and `:GoDoc` no longer exists. This is independent of whether
+> `setup()` runs before or after the plugin is sourced.
 
 See the source for further details:
 

--- a/README.md
+++ b/README.md
@@ -182,16 +182,6 @@ require("godoc").setup({
 })
 ```
 
-> [!NOTE]
->
-> Once you call `setup()`, your configuration is the single source of truth for
-> which commands exist: the auto-registered `:GoDoc` is removed and the commands
-> are registered from your `adapters` list. If your config keeps the default
-> (the go adapter mapped to `"GoDoc"`), `:GoDoc` is re-registered as expected. If
-> you rename the go adapter's command (e.g., `command = "GoDocs"`), only `:GoDocs`
-> is registered and `:GoDoc` no longer exists. This is independent of whether
-> `setup()` runs before or after the plugin is sourced.
-
 See the source for further details:
 
 - Go adapter: [lua/godoc/adapters/go.lua](lua/godoc/adapters/go.lua)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ Fuzzy search Go docs from within Neovim.
 
 > [!TIP]
 >
-> New: define adapters to extend this functionality to other languages/things!
+> - **Works out of the box**: install the plugin and `:GoDoc` just works — no
+>   `setup()` call required. Loading is fully deferred until first invocation.
+> - **Extensible via adapters**: bring your own language/data source (Python,
+>   Rust, dad jokes — whatever you want to pick).
 
 ## Screenshots
 
@@ -30,173 +33,104 @@ _Screenshot is showing the Snacks picker._
 ## Features
 
 - Search and browse docs for Go standard library packages and project packages
-- Go to definition capability
+- Go to definition from picker
 - Optionally leverage [`stdsym`](https://github.com/lotusirous/gostdsym) for
-  symbols searching
-- Optional syntax highlighting using tree-sitter with
-  [tree-sitter-godoc](https://github.com/fredrikaverpil/tree-sitter-godoc) and
-  [tree-sitter-go](https://github.com/tree-sitter/tree-sitter-go) parsers
+  symbol search
+- Optional syntax highlighting via tree-sitter
 - Supports pickers:
   - Native Neovim picker (no preview)
-  - [Telescope](https://github.com/nvim-telescope/telescope.nvim) picker with
-    preview
-  - [Snacks](https://github.com/folke/snacks.nvim) picker with preview
-  - [mini.pick](https://github.com/echasnovski/mini.pick) picker with preview
-  - [fzf-lua](https://github.com/ibhagwan/fzf-lua) picker with preview
-- Adapters can extend functionality to cover other languages (and anything else
-  you might want to pick, really)
+  - [Telescope](https://github.com/nvim-telescope/telescope.nvim) (with preview)
+  - [Snacks](https://github.com/folke/snacks.nvim) (with preview)
+  - [mini.pick](https://github.com/echasnovski/mini.pick) (with preview)
+  - [fzf-lua](https://github.com/ibhagwan/fzf-lua) (with preview)
+- Extend to other languages and data sources via adapters
 
 ## Requirements
 
-- Neovim >= 0.8.0
+- Neovim >= 0.8.0 (>= 0.12 if installing via `vim.pack`)
 - Go installation with `go doc` and `go list` commands available
 
 ## Installation
 
-> [!NOTE]
->
-> Currently only the "go" adapter is built in (and loaded by default), but
-> additional adapters could be implemented.
+Pick whichever plugin manager you use. The built-in `go` adapter is loaded by
+default, so `:GoDoc` works immediately without any `setup()` call — see
+[Configuration](#configuration) if you want to customize.
+
+### Using [vim.pack](https://neovim.io/doc/user/pack.html) (built-in, Neovim 0.12+)
+
+```lua
+vim.pack.add({
+  {
+    src = "https://github.com/fredrikaverpil/godoc.nvim",
+    -- Follow any tagged release. Omit `version` to track the default
+    -- branch (every commit, not just releases).
+    version = vim.version.range("*"),
+  },
+
+  -- Optional picker dependencies — pick whichever you prefer:
+  { src = "https://github.com/nvim-telescope/telescope.nvim" },
+  { src = "https://github.com/folke/snacks.nvim" },
+  { src = "https://github.com/echasnovski/mini.pick" },
+  { src = "https://github.com/ibhagwan/fzf-lua" },
+})
+```
+
+Optionally install [`stdsym`](https://github.com/lotusirous/gostdsym) (enables
+symbol search) on plugin install/update:
+
+```lua
+vim.api.nvim_create_autocmd("PackChanged", {
+  callback = function(ev)
+    if
+      ev.data.spec.name == "godoc.nvim"
+      and (ev.data.kind == "install" or ev.data.kind == "update")
+    then
+      vim.system({
+        "go",
+        "install",
+        "github.com/lotusirous/gostdsym/stdsym@latest",
+      }):wait()
+    end
+  end,
+})
+```
 
 ### Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua
 {
-    "fredrikaverpil/godoc.nvim",
-    version = "*",
-    dependencies = {
-        { "nvim-telescope/telescope.nvim" }, -- optional
-        { "folke/snacks.nvim" }, -- optional
-        { "echasnovski/mini.pick" }, -- optional
-        { "ibhagwan/fzf-lua" }, -- optional
-    },
-    build = "go install github.com/lotusirous/gostdsym/stdsym@latest", -- optional
-    cmd = { "GoDoc" }, -- optional
-    ft = "godoc", -- optional
-    opts = {}, -- see further down below for configuration
+  "fredrikaverpil/godoc.nvim",
+  version = "*",
+  dependencies = {
+    { "nvim-telescope/telescope.nvim" }, -- optional
+    { "folke/snacks.nvim" },             -- optional
+    { "echasnovski/mini.pick" },         -- optional
+    { "ibhagwan/fzf-lua" },              -- optional
+  },
+  build = "go install github.com/lotusirous/gostdsym/stdsym@latest", -- optional
 }
 ```
 
 ### Using [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-" Dependencies
-Plug 'nvim-telescope/telescope.nvim'   " optional
-Plug 'folke/snacks.nvim'               " optional
-Plug 'echasnovski/mini.pick'           " optional
-Plug 'ibhagwan/fzf-lua'                " optional
+" Optional picker dependencies
+Plug 'nvim-telescope/telescope.nvim'
+Plug 'folke/snacks.nvim'
+Plug 'echasnovski/mini.pick'
+Plug 'ibhagwan/fzf-lua'
 
-" Configure the plugin and load it.
-" See the configuration further down below and apply
-" any options to the lua opts table.
 Plug 'fredrikaverpil/godoc.nvim'
-
-lua <<EOF
-local opts = {}
-require('godoc').setup(opts)
-EOF
-```
-
-### Syntax highlighting via tree-sitter parsers
-
-By default, godoc.nvim does not apply any syntax highlighting to `go doc`
-documentation. But by leveraging the
-[tree-sitter-godoc](https://github.com/fredrikaverpil/tree-sitter-godoc) and
-[tree-sitter-go](https://github.com/tree-sitter/tree-sitter-go) parsers, you can
-enable syntax highlighting.
-
-The way it works is by having tree-sitter-godoc provide some basic highlighting,
-but more importantly, identify where actual Go code is. Then, tree-sitter-go can
-step in and provide proper Go code syntax highlighting via injection queries.
-
-**Add tree-sitter as a dependency** and make it aware of the tree-sitter-godoc
-parser:
-
-```lua
-{
-    "fredrikaverpil/godoc.nvim",
-    version = "*",
-    dependencies = {
-        {
-            "nvim-treesitter/nvim-treesitter",
-            branch = "main",
-            build = ":TSUpdate godoc go", -- install/update parsers
-            config = function()
-                require("nvim-treesitter.parsers").godoc = {
-                    install_info = {
-                        url = "https://github.com/fredrikaverpil/tree-sitter-godoc",
-                        files = { "src/parser.c" },
-                        version = "*",
-                    },
-                    filetype = "godoc",
-                }
-
-                -- Map godoc filetype to use godoc parser
-                vim.treesitter.language.register('godoc', 'godoc')
-
-                -- Enable :TSInstall godoc, :TSUpdate godoc
-                vim.api.nvim_create_autocmd("User", {
-                  pattern = "TSUpdate",
-                  callback = function()
-                    require("nvim-treesitter.parsers").godoc = parser_config
-                  end,
-                })
-
-                -- Enable godoc filetype for .godoc files (optional)
-                vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
-                  pattern = "*.godoc",
-                  callback = function()
-                    vim.bo.filetype = "godoc"
-                  end,
-                })
-            end,
-        },
-    },
-    cmd = { "GoDoc" },
-    ft = "godoc",
-    opts = {
-        adapters = {
-            {
-                name = "go",
-                opts = {
-                    get_syntax_info = function()
-                        return {
-                            filetype = "godoc",
-                            language = "godoc",  -- Enable tree-sitter godoc parser
-                        }
-                    end,
-                },
-            },
-        },
-    },
-}
-```
-
-**Install the parsers**:
-
-```vim
-:TSInstall go godoc
 ```
 
 ## Usage
 
-When using the `go` adapter (specified above), the following command is
-provided:
+The built-in `go` adapter provides:
 
-- `:GoDoc` - Open picker and search packages.
-- `:GoDoc <package>` - Directly open documentation for the specified package or
-  symbol.
-- In Normal mode, press `gd` to go package definition (only supported by Snacks
-  and Telescope pickers). For fzf-lua, the keymap is `ctrl-s`.
-
-> [!WARNING]
->
-> The `:GoDoc` command is also used by
-> [x-ray/go.nvim](https://github.com/ray-x/go.nvim). You can disable this by
-> passing `remap_commands = { GoDoc = false }` to x-ray/go.nvim or you can
-> customize the godoc.nvim command.
-
-### Examples
+- `:GoDoc` — open the picker and search packages.
+- `:GoDoc <package>` — open documentation for a specific package or symbol.
+- In the picker, press `gd` to go to the package definition (supported by Snacks
+  and Telescope; for fzf-lua the keymap is `<C-s>`).
 
 ```vim
 :GoDoc                  " browse all standard library packages
@@ -204,177 +138,223 @@ provided:
 :GoDoc strings.Builder  " view documentation for strings.Builder
 ```
 
-## Default configuration (`opts`)
+> [!WARNING]
+>
+> `:GoDoc` is also used by [ray-x/go.nvim](https://github.com/ray-x/go.nvim). To
+> avoid the collision, either pass `remap_commands = { GoDoc = false }` to
+> go.nvim or rename the godoc.nvim command (see
+> [Configuration](#configuration)).
+
+## Configuration
+
+`:GoDoc` works with defaults out of the box. Call `setup()` only if you want to
+customize behavior — any options you omit fall back to the defaults below.
 
 ```lua
-local godoc = require("godoc")
-
----@type godoc.types.GoDocConfig
-{
-    adapters = {
-        -- for details, see lua/godoc/adapters/go.lua
-        {
-            name = "go",
-            opts = {
-                command = "GoDoc", -- the vim command to invoke Go documentation
-                get_syntax_info = function()
-                    return {
-                        filetype = "godoc", -- filetype for the buffer
-                        language = "", -- tree-sitter parser, for syntax highlighting
-                    }
-                end,
-            },
-        },
+require("godoc").setup({
+  adapters = {
+    {
+      name = "go",
+      opts = {
+        command = "GoDoc", -- the vim command to invoke Go documentation
+        get_syntax_info = function()
+          return {
+            filetype = "godoc", -- filetype of the documentation buffer
+            language = "",      -- tree-sitter parser, for syntax highlighting
+          }
+        end,
+      },
     },
-    window = {
-        type = "split", -- split | vsplit
-    },
-    picker = {
-        type = "native", -- native (vim.ui.select) | telescope | snacks | mini | fzf_lua
+  },
+  window = {
+    type = "split", -- split | vsplit
+  },
+  picker = {
+    type = "native", -- native (vim.ui.select) | telescope | snacks | mini | fzf_lua
 
-        -- see respective picker in lua/godoc/pickers for available options
-        native = {},
-        telescope = {},
-        snacks = {},
-        mini = {},
-        fzf_lua = {},
-    },
-}
-```
-
-For further details, see the actual implementation.
-
-Adapters:
-
-- [lua/godoc/adapters/go.lua](lua/godoc/adapters/go.lua)
-
-Pickers
-
-- [lua/godoc/pickers/native.lua](lua/godoc/pickers/native.lua)
-- [lua/godoc/pickers/telescope.lua](lua/godoc/pickers/telescope.lua)
-- [lua/godoc/pickers/snacks.lua](lua/godoc/pickers/snacks.lua)
-- [lua/godoc/pickers/mini.lua](lua/godoc/pickers/mini.lua)
-- [lua/godoc/pickers/fzf_lua.lua](lua/godoc/pickers/fzf_lua.lua)
-
-## Health Check
-
-The plugin includes a health check. It will run the checks associated with the
-adapters you have enabled (and which have specified a health check).
-
-```vim
-:checkhealth godoc
-```
-
-## Adapters
-
-It's possible to extend the functionality of godoc.nvim with adapters. There are
-different kinds of adapters:
-
-- Built-in, added to this very project, into the
-  [lua/godoc/adapters](lua/godoc/adapters) directory.
-- User-defined, defined inline in the user's own config.
-- Third-party, defined in a different git repo and pulled in as separate
-  dependency.
-
-For all these kinds of adapters, it's possible to perform user-provided
-overrides.
-
-```lua
-{
-    "fredrikaverpil/godoc.nvim",
-    version = "*",
-    dependencies = {
-        {
-            "nvim-treesitter/nvim-treesitter",
-            opts = {
-              ensure_installed = { "go", "mylang", "python" },
-            },
-        },
-        { "someuser/pydoc.nvim" }, -- third-party
-    },
-    opts = {
-        adapters = {
-            -- built-in
-            { name = "go" },
-
-            -- built-in, but with user-override
-            { name = "go", opts = { command = "MyCustomCommand" }, },
-
-            -- user-provided (note the omission of a 'name' field)
-            {
-                command = "MyDoc",
-                get_items = function()
-                    return vim.fn.systemlist("mylang doc --list")
-                end,
-                get_content = function(choice)
-                    return vim.fn.systemlist("mylang doc " .. choice)
-                end,
-                get_syntax_info = function()
-                    return {
-                        filetype = "mydoc", -- filetype for buffer that is opened
-                        language = "mylang" -- tree-sitter parser
-                    }
-                end
-            },
-
-            -- user-provided (another example)
-            {
-                command = "DadJokes",
-                get_items = function()
-                    return { "coffee", "pasta" }
-                end,
-                get_content = function(choice)
-                    local db = {
-                        coffee = {
-                            "What did the coffee report to the police?",
-                            "A mugging!"
-                        },
-                        pasta = {
-                            "What do you call a fake noodle?",
-                            "An impasta!"
-                        },
-                    }
-                    return db[choice]
-                end,
-                get_syntax_info = function()
-                    return {
-                        filetype = "text",
-                        language = "text",
-                    }
-                end,
-            },
-
-            -- third-party
-            {
-                setup = function()
-                    opts = {...} -- third-party opts
-                    return require("pydoc.nvim").setup(opts)
-                end,
-            },
-
-            -- third-party with user-override
-            {
-                setup = function()
-                    opts = {...} -- third-party opts
-                    return require("pydoc.nvim").setup(opts)
-                end,
-                opts = {
-                    command = "CustomPyDocCommand",
-                },
-            },
-        }
-    },
-}
+    -- per-picker options (see lua/godoc/pickers/<name>.lua for available fields)
+    native = {},
+    telescope = {},
+    snacks = {},
+    mini = {},
+    fzf_lua = {},
+  },
+})
 ```
 
 > [!NOTE]
 >
-> The `pydoc.nvim` and `mylang` above are just fictional examples to illustrate
-> functionality.
+> Calling `setup()` does not disturb the auto-registered `:GoDoc` unless your
+> config explicitly claims the `"GoDoc"` command name for a specific adapter —
+> in which case that adapter takes it over. This way you can rename the go
+> adapter's command (e.g., `command = "GoDocs"`) and still keep the built-in
+> `:GoDoc` running the defaults alongside, or reassign `:GoDoc` to a different
+> adapter entirely if that's what you want.
+
+See the source for further details:
+
+- Go adapter: [lua/godoc/adapters/go.lua](lua/godoc/adapters/go.lua)
+- Pickers: [lua/godoc/pickers/](lua/godoc/pickers/)
+- Types: [lua/godoc/types.lua](lua/godoc/types.lua)
+
+## Syntax highlighting via tree-sitter
+
+By default, `go doc` output is rendered without syntax highlighting. You can opt
+in by installing the
+[tree-sitter-godoc](https://github.com/fredrikaverpil/tree-sitter-godoc) and
+[tree-sitter-go](https://github.com/tree-sitter/tree-sitter-go) parsers.
+tree-sitter-godoc provides base highlighting and uses injection queries to hand
+off Go code regions to tree-sitter-go.
+
+### 1. Install nvim-treesitter
+
+Install [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
+using your plugin manager of choice (branch `main`).
+
+### 2. Register the `godoc` parser
+
+Run this once at startup (for example, in your `init.lua`):
+
+```lua
+local godoc_parser = {
+  install_info = {
+    url = "https://github.com/fredrikaverpil/tree-sitter-godoc",
+    files = { "src/parser.c" },
+    version = "*",
+  },
+  filetype = "godoc",
+}
+
+require("nvim-treesitter.parsers").godoc = godoc_parser
+
+-- Map godoc filetype to the godoc parser
+vim.treesitter.language.register("godoc", "godoc")
+
+-- Re-register after :TSUpdate so the parser survives parser-list reloads
+vim.api.nvim_create_autocmd("User", {
+  pattern = "TSUpdate",
+  callback = function()
+    require("nvim-treesitter.parsers").godoc = godoc_parser
+  end,
+})
+
+-- Optional: also use the godoc filetype for `.godoc` files
+vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
+  pattern = "*.godoc",
+  callback = function()
+    vim.bo.filetype = "godoc"
+  end,
+})
+```
+
+### 3. Install the parsers
+
+```vim
+:TSInstall go godoc
+```
+
+### 4. Tell godoc.nvim to use the godoc parser
+
+Override the go adapter's `get_syntax_info` in your `setup()` call:
+
+```lua
+require("godoc").setup({
+  adapters = {
+    {
+      name = "go",
+      opts = {
+        get_syntax_info = function()
+          return {
+            filetype = "godoc",
+            language = "godoc",
+          }
+        end,
+      },
+    },
+  },
+})
+```
+
+## Adapters
+
+godoc.nvim is extensible via adapters. Three flavors are supported:
+
+- **Built-in** — shipped in [lua/godoc/adapters/](lua/godoc/adapters/). Only
+  `go` today.
+- **User-defined** — written inline in your own config.
+- **Third-party** — installed as a separate plugin that exposes a `setup()`
+  function returning a `GoDocAdapter`.
+
+You can override any adapter's options (including the command name) via `opts`.
+
+```lua
+require("godoc").setup({
+  adapters = {
+    -- Built-in, default options
+    { name = "go" },
+
+    -- Built-in with user override (rename command)
+    { name = "go", opts = { command = "GoDocs" } },
+
+    -- User-defined (no `name` field)
+    {
+      command = "MyDoc",
+      get_items = function()
+        return vim.fn.systemlist("mylang doc --list")
+      end,
+      get_content = function(choice)
+        return vim.fn.systemlist("mylang doc " .. choice)
+      end,
+      get_syntax_info = function()
+        return { filetype = "mydoc", language = "mylang" }
+      end,
+      goto_definition = function() end,
+    },
+
+    -- User-defined, purely for fun
+    {
+      command = "DadJokes",
+      get_items = function()
+        return { "coffee", "pasta" }
+      end,
+      get_content = function(choice)
+        local db = {
+          coffee = { "What did the coffee report to the police?", "A mugging!" },
+          pasta  = { "What do you call a fake noodle?",            "An impasta!" },
+        }
+        return db[choice]
+      end,
+      get_syntax_info = function()
+        return { filetype = "text", language = "text" }
+      end,
+      goto_definition = function() end,
+    },
+
+    -- Third-party
+    {
+      setup = function()
+        return require("pydoc.nvim").setup({ --[[ third-party opts ]] })
+      end,
+    },
+
+    -- Third-party with override
+    {
+      setup = function()
+        return require("pydoc.nvim").setup({ --[[ third-party opts ]] })
+      end,
+      opts = { command = "PyDocs" },
+    },
+  },
+})
+```
+
+> [!NOTE]
+>
+> `pydoc.nvim` and `mylang` above are fictional — illustrative only.
 
 ### Adapter interface
 
-All adapters must implement the interface of `GoDocAdapter`:
+All adapters must implement the `GoDocAdapter` interface:
 
 ```lua
 --- @class GoDocAdapter
@@ -386,8 +366,7 @@ All adapters must implement the interface of `GoDocAdapter`:
 --- @field health? fun(): GoDocHealthCheck[] Optional health check function
 ```
 
-The `opts` which can be passed into an adapter (by the user) is implemented by
-`GoDocAdapterOpts`:
+User overrides use `GoDocAdapterOpts`:
 
 ```lua
 --- @class GoDocAdapterOpts
@@ -400,16 +379,20 @@ The `opts` which can be passed into an adapter (by the user) is implemented by
 --- @field [string] any Other adapter-specific options
 ```
 
-- See the example implementation for the built-in Go adapter at
-  [lua/adapters/go.lua](lua/adapters/go.lua).
-- If implementing a third-party adapter, make sure it has an exposed `setup`
-  function which returns a `GoDocAdapter`.
+See [lua/godoc/adapters/go.lua](lua/godoc/adapters/go.lua) for a reference
+implementation, and [lua/godoc/types.lua](lua/godoc/types.lua) for the full type
+definitions.
 
-The `GoDocAdapter` type is defined in
-[lua/godoc/types.lua](lua/godoc/types.lua).
+Pull requests for new built-in adapters or improvements to existing ones are
+welcome!
 
-Feel free to open a pull request if you want to add a new built-in adapter or
-improve on existing ones!
+## Health Check
+
+```vim
+:checkhealth godoc
+```
+
+Runs the health checks associated with every enabled adapter that provides one.
 
 ## Contributing
 

--- a/lua/godoc/health.lua
+++ b/lua/godoc/health.lua
@@ -5,17 +5,16 @@ local M = {}
 function M.check()
   health.start("godoc.nvim")
 
-  -- Check plugin setup
-  local config = require("godoc").config
-  if not config then
-    health.error("Plugin not configured")
-    return
+  -- Report configuration source. The plugin works without setup(): plugin/godoc.lua
+  -- auto-registers :GoDoc against the defaults, so "no setup()" is healthy, not an error.
+  local godoc = require("godoc")
+  if godoc.config then
+    health.ok("Plugin configured via setup()")
   else
-    health.ok("Plugin configured")
+    health.ok("Running with default configuration (setup() not called)")
   end
 
   -- Ensure adapters are initialized so health checks work even if no command has been run yet.
-  local godoc = require("godoc")
   godoc._ensure_initialized()
 
   for _, adapter in pairs(godoc._adapters) do

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -224,7 +224,12 @@ local function register_eager(adapter_config)
   local syntax = final_adapter.get_syntax_info()
   vim.treesitter.language.register(syntax.language, { syntax.filetype })
   M._adapters[final_adapter.command] = final_adapter
-  register_command(final_adapter.command)
+
+  -- Skip if a command with this name already exists (e.g., registered
+  -- by another plugin, or the user's vimrc) — don't clobber.
+  if vim.fn.exists(":" .. final_adapter.command) == 0 then
+    register_command(final_adapter.command)
+  end
 end
 
 -- Set up the plugin with user config

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -106,7 +106,9 @@ function M._ensure_initialized()
   end
   M._lazy_initialized = true
 
-  local configured = configure_adapters(M.config)
+  -- Fall back to defaults when setup() was never called so the auto-registered
+  -- :GoDoc (and :checkhealth) work out of the box.
+  local configured = configure_adapters(M.config or M.defaults)
   for _, adapter in ipairs(configured) do
     -- Skip adapters that were already eagerly initialized
     if not M._adapters[adapter.command] then

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -42,7 +42,7 @@ end
 
 --- @param adapter_config GoDocAdapterConfig
 --- @return string?
-local function configured_command(adapter_config)
+local function adapter_command(adapter_config)
   return (adapter_config.opts and adapter_config.opts.command)
     or adapter_config.command
 end
@@ -115,7 +115,7 @@ local function configure_adapters(config)
 
       if is_third_party_adapter(adapter_config) then
         ---@cast adapter_config GoDocThirdPartyAdapter
-        if configured_command(adapter_config) then
+        if adapter_command(adapter_config) then
           adapter = configure_third_party_adapter(adapter_config, adapters)
         else
           -- Already initialized eagerly by register_eager in setup(): its command
@@ -141,6 +141,14 @@ local function configure_adapters(config)
   return configured_adapters
 end
 
+--- Register syntax highlighting metadata and remember the adapter by command.
+--- @param adapter GoDocAdapter
+local function activate_adapter(adapter)
+  local syntax = adapter.get_syntax_info()
+  vim.treesitter.language.register(syntax.language, { syntax.filetype })
+  M._adapters[adapter.command] = adapter
+end
+
 --- Lazy-initialize adapters and treesitter on first command use.
 --- Also called by health.lua so :checkhealth works before any command is run.
 function M._ensure_initialized()
@@ -155,9 +163,7 @@ function M._ensure_initialized()
   for _, adapter in ipairs(configured) do
     -- Skip adapters that were already eagerly initialized
     if not M._adapters[adapter.command] then
-      local syntax = adapter.get_syntax_info()
-      vim.treesitter.language.register(syntax.language, { syntax.filetype })
-      M._adapters[adapter.command] = adapter
+      activate_adapter(adapter)
     end
   end
 end
@@ -239,6 +245,14 @@ local function register_command(command)
   )
 end
 
+--- Register a user command unless something else already owns that name.
+--- @param command string
+local function register_command_if_available(command)
+  if vim.fn.exists(":" .. command) == 0 then
+    register_command(command)
+  end
+end
+
 --- Eagerly initialize a single adapter and register its command.
 --- Used for third-party adapters whose command name is only known at runtime.
 --- @param adapter_config table
@@ -248,15 +262,8 @@ local function register_eager(adapter_config)
   if not final_adapter then
     return
   end
-  local syntax = final_adapter.get_syntax_info()
-  vim.treesitter.language.register(syntax.language, { syntax.filetype })
-  M._adapters[final_adapter.command] = final_adapter
-
-  -- Skip if a command with this name already exists (e.g., registered
-  -- by another plugin, or the user's vimrc) — don't clobber.
-  if vim.fn.exists(":" .. final_adapter.command) == 0 then
-    register_command(final_adapter.command)
-  end
+  activate_adapter(final_adapter)
+  register_command_if_available(final_adapter.command)
 end
 
 -- Set up the plugin with user config
@@ -296,13 +303,9 @@ function M.setup(opts)
   end
 
   for _, adapter_config in ipairs(M.config.adapters) do
-    local command = configured_command(adapter_config)
+    local command = adapter_command(adapter_config)
     if command then
-      -- Skip if a command with this name already exists (e.g., registered
-      -- by another plugin, or the user's vimrc) — don't clobber.
-      if vim.fn.exists(":" .. command) == 0 then
-        register_command(command)
-      end
+      register_command_if_available(command)
     elseif is_third_party_adapter(adapter_config) then
       -- Third-party adapter without opts.command — must call setup() to learn the command name
       register_eager(adapter_config)

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -244,25 +244,15 @@ function M.setup(opts)
   -- auto-register :GoDoc (in case plugin scripts load after user init).
   vim.g._godoc_user_configured = true
 
-  -- If any adapter in the user's config explicitly claims the "GoDoc" command
-  -- name, remove the auto-registered :GoDoc so the loop below can assign it.
-  -- Otherwise leave :GoDoc alone — the user hasn't asked for it to change, so
-  -- it keeps serving the built-in default alongside any additional commands
-  -- they configure.
+  -- Remove the command auto-registered by plugin/godoc.lua so the loop below is
+  -- the single source of truth for which commands exist. This keeps the end
+  -- state independent of load order: whether setup() runs before or after
+  -- plugin/godoc.lua, the resulting commands are exactly what the config asks
+  -- for. If the config still maps an adapter to that name (the default), the
+  -- loop re-registers it; if the user renamed it, the old command is gone.
   if vim.g._godoc_auto_registered then
-    local user_claims_godoc = false
-    for _, adapter_config in ipairs(M.config.adapters) do
-      local cmd = (adapter_config.opts and adapter_config.opts.command)
-        or adapter_config.command
-      if cmd == "GoDoc" then
-        user_claims_godoc = true
-        break
-      end
-    end
-    if user_claims_godoc then
-      pcall(vim.api.nvim_del_user_command, "GoDoc")
-      vim.g._godoc_auto_registered = false
-    end
+    pcall(vim.api.nvim_del_user_command, vim.g._godoc_auto_registered)
+    vim.g._godoc_auto_registered = nil
   end
 
   for _, adapter_config in ipairs(M.config.adapters) do

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -24,9 +24,9 @@ M.defaults = {
   },
 }
 
--- Final configuration (defaults + user-provided) after setup.
+-- Active configuration. Starts with defaults so :GoDoc works without setup().
 --- @type GoDocConfig
-M.config = nil
+M.config = vim.deepcopy(M.defaults)
 
 -- The configured adapters, keyed by command name.
 --- @type table<string, GoDocAdapter>
@@ -157,9 +157,7 @@ function M._ensure_initialized()
   end
   M._lazy_initialized = true
 
-  -- Fall back to defaults when setup() was never called so the auto-registered
-  -- :GoDoc (and :checkhealth) work out of the box.
-  local configured = configure_adapters(M.config or M.defaults)
+  local configured = configure_adapters(M.config)
   for _, adapter in ipairs(configured) do
     -- Skip adapters that were already eagerly initialized
     if not M._adapters[adapter.command] then
@@ -179,46 +177,39 @@ local function open_window(type)
 end
 
 --- Run the picker/documentation flow for the given adapter.
---- Uses M.config when setup() has been called, otherwise falls back to defaults
---- so plugin/godoc.lua's auto-registered :GoDoc works without setup().
 --- @param adapter GoDocAdapter
 --- @param args table command arguments table from nvim_create_user_command
 local function dispatch(adapter, args)
-  local config = M.config or M.defaults
-
   if args.args ~= nil and args.args ~= "" then
     M.show_documentation(adapter, args.args)
     return
   end
 
   local pickers = require("godoc.pickers")
-  local picker = pickers.get_picker(config.picker.type)
+  local picker = pickers.get_picker(M.config.picker.type)
   if not picker then
     vim.notify(
-      "Picker not implemented: " .. config.picker.type,
+      "Picker not implemented: " .. M.config.picker.type,
       vim.log.levels.ERROR
     )
     return
   end
 
   ---@type GoDocPicker
-  picker.show(adapter, config, function(data)
+  picker.show(adapter, M.config, function(data)
     if data.choice then
       if data.type == "show_documentation" then
-        open_window(config.window.type)
+        open_window(M.config.window.type)
         M.show_documentation(adapter, data.choice)
       elseif data.type == "goto_definition" then
-        open_window(config.window.type)
+        open_window(M.config.window.type)
         M.goto_definition(adapter, data.choice, picker.goto_definition)
       end
     end
   end)
 end
 
---- Command callback shared by setup()-registered commands and the command
---- auto-registered in plugin/godoc.lua. Looks up the adapter by the invoked
---- command name and dispatches to it, initializing adapters lazily on first use
---- so the plugin works even when setup() was never called.
+--- Command callback shared by setup()-registered commands and the auto command.
 --- @param args table command arguments table from nvim_create_user_command
 function M._dispatch_command(args)
   M._ensure_initialized()
@@ -245,12 +236,38 @@ local function register_command(command)
   )
 end
 
---- Register a user command unless something else already owns that name.
+--- Register a user command unless something else already owns that exact name.
 --- @param command string
+--- @return boolean
 local function register_command_if_available(command)
-  if vim.fn.exists(":" .. command) == 0 then
+  if vim.api.nvim_get_commands({})[command] == nil then
     register_command(command)
+    return true
   end
+
+  vim.notify(
+    string.format(
+      "Command :%s already exists; choose another adapter command in setup()",
+      command
+    ),
+    vim.log.levels.WARN
+  )
+  return false
+end
+
+--- Remove the zero-config command registered by plugin/godoc.lua, if present.
+local function remove_auto_command()
+  if vim.g.godoc_auto_command then
+    pcall(vim.api.nvim_del_user_command, vim.g.godoc_auto_command)
+    vim.g.godoc_auto_command = nil
+  end
+end
+
+--- Reset runtime state before applying user configuration.
+local function reset_runtime()
+  M._adapters = {}
+  M._lazy_initialized = false
+  remove_auto_command()
 end
 
 --- Eagerly initialize a single adapter and register its command.
@@ -277,26 +294,10 @@ function M.setup(opts)
     M.config.adapters = opts.adapters
   end
 
-  -- Discard adapters initialized from a previous/default configuration. This
-  -- lets setup() take effect even if :GoDoc or :checkhealth already triggered
-  -- lazy initialization before the user configuration was applied.
-  M._adapters = {}
-  M._lazy_initialized = false
-
-  -- Tell plugin/godoc.lua that the user owns the plugin — it should not
-  -- auto-register :GoDoc (in case plugin scripts load after user init).
-  vim.g._godoc_user_configured = true
-
-  -- Remove the command auto-registered by plugin/godoc.lua so the loop below is
-  -- the single source of truth for which commands exist. This keeps the end
-  -- state independent of load order: whether setup() runs before or after
-  -- plugin/godoc.lua, the resulting commands are exactly what the config asks
-  -- for. If the config still maps an adapter to that name (the default), the
-  -- loop re-registers it; if the user renamed it, the old command is gone.
-  if vim.g._godoc_auto_registered then
-    pcall(vim.api.nvim_del_user_command, vim.g._godoc_auto_registered)
-    vim.g._godoc_auto_registered = nil
-  end
+  -- Make setup() the single source of truth, even if the default :GoDoc command
+  -- or default adapters were initialized before user config was applied.
+  vim.g.godoc_user_configured = true
+  reset_runtime()
 
   for _, adapter_config in ipairs(M.config.adapters) do
     local command = adapter_command(adapter_config)

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -166,31 +166,12 @@ local function dispatch(adapter, args)
   end)
 end
 
---- Create a user command that delegates to the given adapter.
---- @param command string
-local function register_command(command)
-  vim.api.nvim_create_user_command(command, function(args)
-    M._ensure_initialized()
-
-    local adapter = M._adapters[command]
-    if not adapter then
-      vim.notify(
-        "No adapter found for command: " .. command,
-        vim.log.levels.ERROR
-      )
-      return
-    end
-
-    dispatch(adapter, args)
-  end, { nargs = "?" })
-end
-
---- Entry point for the command auto-registered by plugin/godoc.lua, so it works
---- out-of-the-box without the user calling setup(). Initializes the default
---- adapters lazily (_ensure_initialized falls back to M.defaults) and dispatches
---- the adapter whose command matches the one that was invoked.
+--- Command callback shared by setup()-registered commands and the command
+--- auto-registered in plugin/godoc.lua. Looks up the adapter by the invoked
+--- command name and dispatches to it, initializing adapters lazily on first use
+--- so the plugin works even when setup() was never called.
 --- @param args table command arguments table from nvim_create_user_command
-function M._run_default_go(args)
+function M._dispatch_command(args)
   M._ensure_initialized()
 
   local adapter = M._adapters[args.name]
@@ -203,6 +184,16 @@ function M._run_default_go(args)
   end
 
   dispatch(adapter, args)
+end
+
+--- Create a user command that delegates to its matching adapter.
+--- @param command string
+local function register_command(command)
+  vim.api.nvim_create_user_command(
+    command,
+    M._dispatch_command,
+    { nargs = "?" }
+  )
 end
 
 --- Eagerly initialize a single adapter and register its command.

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -242,6 +242,12 @@ function M.setup(opts)
     M.config.adapters = opts.adapters
   end
 
+  -- Discard adapters initialized from a previous/default configuration. This
+  -- lets setup() take effect even if :GoDoc or :checkhealth already triggered
+  -- lazy initialization before the user configuration was applied.
+  M._adapters = {}
+  M._lazy_initialized = false
+
   -- Tell plugin/godoc.lua that the user owns the plugin — it should not
   -- auto-register :GoDoc (in case plugin scripts load after user init).
   vim.g._godoc_user_configured = true

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -232,6 +232,16 @@ end
 function M.setup(opts)
   M.config = vim.tbl_deep_extend("force", M.defaults, opts or {})
 
+  -- A user-supplied adapters list replaces the defaults wholesale rather than
+  -- being merged in. adapters is an ordered list, not a keyed map, so
+  -- positional merging is meaningless (and vim.tbl_deep_extend's handling of
+  -- list-like tables is not something we want to rely on). Setting it
+  -- explicitly keeps the contract obvious: provide adapters and you own the
+  -- whole list.
+  if opts and opts.adapters then
+    M.config.adapters = opts.adapters
+  end
+
   -- Tell plugin/godoc.lua that the user owns the plugin — it should not
   -- auto-register :GoDoc (in case plugin scripts load after user init).
   vim.g._godoc_user_configured = true

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -127,6 +127,43 @@ local function open_window(type)
   end
 end
 
+--- Run the picker/documentation flow for the given adapter.
+--- Uses M.config when setup() has been called, otherwise falls back to defaults
+--- so plugin/godoc.lua's auto-registered :GoDoc works without setup().
+--- @param adapter GoDocAdapter
+--- @param args table command arguments table from nvim_create_user_command
+local function dispatch(adapter, args)
+  local config = M.config or M.defaults
+
+  if args.args ~= nil and args.args ~= "" then
+    M.show_documentation(adapter, args.args)
+    return
+  end
+
+  local pickers = require("godoc.pickers")
+  local picker = pickers.get_picker(config.picker.type)
+  if not picker then
+    vim.notify(
+      "Picker not implemented: " .. config.picker.type,
+      vim.log.levels.ERROR
+    )
+    return
+  end
+
+  ---@type GoDocPicker
+  picker.show(adapter, config, function(data)
+    if data.choice then
+      if data.type == "show_documentation" then
+        open_window(config.window.type)
+        M.show_documentation(adapter, data.choice)
+      elseif data.type == "goto_definition" then
+        open_window(config.window.type)
+        M.goto_definition(adapter, data.choice, picker.goto_definition)
+      end
+    end
+  end)
+end
+
 --- Create a user command that delegates to the given adapter.
 --- @param command string
 local function register_command(command)
@@ -142,35 +179,38 @@ local function register_command(command)
       return
     end
 
-    -- If args were passed, show documentation directly
-    if args.args ~= nil and args.args ~= "" then
-      M.show_documentation(adapter, args.args)
-      return
-    end
-
-    -- Show picker
-    local pickers = require("godoc.pickers")
-    local picker = pickers.get_picker(M.config.picker.type)
-    if picker then
-      ---@type GoDocPicker
-      picker.show(adapter, M.config, function(data)
-        if data.choice then
-          if data.type == "show_documentation" then
-            open_window(M.config.window.type)
-            M.show_documentation(adapter, data.choice)
-          elseif data.type == "goto_definition" then
-            open_window(M.config.window.type)
-            M.goto_definition(adapter, data.choice, picker.goto_definition)
-          end
-        end
-      end)
-    else
-      vim.notify(
-        "Picker not implemented: " .. M.config.picker.type,
-        vim.log.levels.ERROR
-      )
-    end
+    dispatch(adapter, args)
   end, { nargs = "?" })
+end
+
+--- Run the built-in go adapter. Entry point for plugin/godoc.lua's :GoDoc so
+--- that the command works out-of-the-box without the user calling setup().
+--- Honors user overrides from M.config.adapters when setup() has been called.
+--- @param args table command arguments table from nvim_create_user_command
+function M._run_default_go(args)
+  local config = M.config or M.defaults
+  local adapters = require("godoc.adapters")
+
+  local default_adapter = adapters.get_adapter("go")
+  if not default_adapter then
+    vim.notify("Built-in go adapter not available", vim.log.levels.ERROR)
+    return
+  end
+
+  -- Apply user's go adapter overrides (if any) so customizations propagate to :GoDoc.
+  local go_opts
+  for _, adapter_config in ipairs(config.adapters or {}) do
+    if adapter_config.name == "go" then
+      go_opts = adapter_config.opts
+      break
+    end
+  end
+  local adapter = adapters.override_adapter(default_adapter, go_opts)
+
+  local syntax = adapter.get_syntax_info()
+  vim.treesitter.language.register(syntax.language, { syntax.filetype })
+
+  dispatch(adapter, args)
 end
 
 --- Eagerly initialize a single adapter and register its command.
@@ -200,12 +240,40 @@ end
 function M.setup(opts)
   M.config = vim.tbl_deep_extend("force", M.defaults, opts or {})
 
+  -- Tell plugin/godoc.lua that the user owns the plugin — it should not
+  -- auto-register :GoDoc (in case plugin scripts load after user init).
+  vim.g._godoc_user_configured = true
+
+  -- If any adapter in the user's config explicitly claims the "GoDoc" command
+  -- name, remove the auto-registered :GoDoc so the loop below can assign it.
+  -- Otherwise leave :GoDoc alone — the user hasn't asked for it to change, so
+  -- it keeps serving the built-in default alongside any additional commands
+  -- they configure.
+  if vim.g._godoc_auto_registered then
+    local user_claims_godoc = false
+    for _, adapter_config in ipairs(M.config.adapters) do
+      local cmd = (adapter_config.opts and adapter_config.opts.command)
+        or adapter_config.command
+      if cmd == "GoDoc" then
+        user_claims_godoc = true
+        break
+      end
+    end
+    if user_claims_godoc then
+      pcall(vim.api.nvim_del_user_command, "GoDoc")
+      vim.g._godoc_auto_registered = false
+    end
+  end
+
   for _, adapter_config in ipairs(M.config.adapters) do
     local command = (adapter_config.opts and adapter_config.opts.command)
       or adapter_config.command
     if command then
-      -- Command name known from config — register lazily
-      register_command(command)
+      -- Skip if a command with this name already exists (e.g., registered
+      -- by another plugin, or the user's vimrc) — don't clobber.
+      if vim.fn.exists(":" .. command) == 0 then
+        register_command(command)
+      end
     elseif
       adapter_config.setup and type(adapter_config.setup) == "function"
     then

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -244,15 +244,8 @@ end
 --- @param adapter_config table
 local function register_eager(adapter_config)
   local adapters = require("godoc.adapters")
-  local default_adapter = adapter_config.setup()
-  local final_adapter =
-    adapters.override_adapter(default_adapter, adapter_config.opts)
-  local is_valid, error_message = adapters.validate_adapter(final_adapter)
-  if not is_valid then
-    vim.notify(
-      string.format("Invalid third-party adapter: %s", error_message),
-      vim.log.levels.WARN
-    )
+  local final_adapter = configure_third_party_adapter(adapter_config, adapters)
+  if not final_adapter then
     return
   end
   local syntax = final_adapter.get_syntax_info()

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -50,7 +50,16 @@ local function configure_adapters(config)
 
   for _, adapter_config in ipairs(config.adapters) do
     if type(adapter_config) == "table" then
-      if adapter_config.setup and type(adapter_config.setup) == "function" then
+      local is_third_party = adapter_config.setup
+        and type(adapter_config.setup) == "function"
+      local has_command = (adapter_config.opts and adapter_config.opts.command)
+        or adapter_config.command
+
+      if is_third_party and not has_command then
+        -- Already initialized eagerly by register_eager in setup(): its command
+        -- name is only known after calling setup(), so calling setup() again
+        -- here would duplicate any side effects and re-emit validation warnings.
+      elseif is_third_party then
         -- Handle third-party adapter
         local default_adapter = adapter_config.setup() -- Get default adapter implementation
         local final_adapter =

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -272,11 +272,7 @@ function M.setup(opts)
   M.config = vim.tbl_deep_extend("force", M.defaults, opts or {})
 
   -- A user-supplied adapters list replaces the defaults wholesale rather than
-  -- being merged in. adapters is an ordered list, not a keyed map, so
-  -- positional merging is meaningless (and vim.tbl_deep_extend's handling of
-  -- list-like tables is not something we want to rely on). Setting it
-  -- explicitly keeps the contract obvious: provide adapters and you own the
-  -- whole list.
+  -- being merged in.
   if opts and opts.adapters then
     M.config.adapters = opts.adapters
   end

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -310,9 +310,7 @@ function M.setup(opts)
       if vim.fn.exists(":" .. command) == 0 then
         register_command(command)
       end
-    elseif
-      adapter_config.setup and type(adapter_config.setup) == "function"
-    then
+    elseif is_third_party_adapter(adapter_config) then
       -- Third-party adapter without opts.command — must call setup() to learn the command name
       register_eager(adapter_config)
     end

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -34,6 +34,67 @@ M._adapters = {}
 
 M._lazy_initialized = false
 
+--- @param adapter_config GoDocAdapterConfig
+--- @return boolean
+local function is_third_party_adapter(adapter_config)
+  return type(adapter_config.setup) == "function"
+end
+
+--- @param adapter_config GoDocAdapterConfig
+--- @return string?
+local function configured_command(adapter_config)
+  return (adapter_config.opts and adapter_config.opts.command)
+    or adapter_config.command
+end
+
+--- @param adapter_config GoDocThirdPartyAdapter
+--- @param adapters table
+--- @return GoDocAdapter?
+local function configure_third_party_adapter(adapter_config, adapters)
+  local default_adapter = adapter_config.setup()
+  local final_adapter =
+    adapters.override_adapter(default_adapter, adapter_config.opts)
+  local is_valid, error_message = adapters.validate_adapter(final_adapter)
+  if is_valid then
+    return final_adapter
+  end
+
+  vim.notify(
+    string.format("Invalid third-party adapter: %s", error_message),
+    vim.log.levels.WARN
+  )
+end
+
+--- @param adapter_config GoDocBuiltinAdapter
+--- @param adapters table
+--- @return GoDocAdapter?
+local function configure_builtin_adapter(adapter_config, adapters)
+  local default_adapter = adapters.get_adapter(adapter_config.name)
+  if default_adapter ~= nil then
+    return adapters.override_adapter(default_adapter, adapter_config.opts)
+  end
+
+  vim.notify(
+    string.format("Adapter %s not found", adapter_config.name),
+    vim.log.levels.WARN
+  )
+end
+
+--- @param adapter_config GoDocUserAdapter
+--- @param adapters table
+--- @return GoDocAdapter?
+local function configure_user_adapter(adapter_config, adapters)
+  local is_valid, error_message = adapters.validate_adapter(adapter_config)
+  if is_valid then
+    return adapter_config
+  end
+
+  vim.notify(
+    string.format("Invalid user-defined adapter: %s", error_message),
+    vim.log.levels.WARN
+  )
+end
+
 --- @param config GoDocConfig
 local function configure_adapters(config)
   local adapters = require("godoc.adapters")
@@ -50,56 +111,29 @@ local function configure_adapters(config)
 
   for _, adapter_config in ipairs(config.adapters) do
     if type(adapter_config) == "table" then
-      local is_third_party = adapter_config.setup
-        and type(adapter_config.setup) == "function"
-      local has_command = (adapter_config.opts and adapter_config.opts.command)
-        or adapter_config.command
+      local adapter
 
-      if is_third_party and not has_command then
-        -- Already initialized eagerly by register_eager in setup(): its command
-        -- name is only known after calling setup(), so calling setup() again
-        -- here would duplicate any side effects and re-emit validation warnings.
-      elseif is_third_party then
-        -- Handle third-party adapter
-        local default_adapter = adapter_config.setup() -- Get default adapter implementation
-        local final_adapter =
-          adapters.override_adapter(default_adapter, adapter_config.opts)
-        local is_valid, error_message = adapters.validate_adapter(final_adapter)
-        if is_valid then
-          table.insert(configured_adapters, final_adapter)
+      if is_third_party_adapter(adapter_config) then
+        ---@cast adapter_config GoDocThirdPartyAdapter
+        if configured_command(adapter_config) then
+          adapter = configure_third_party_adapter(adapter_config, adapters)
         else
-          vim.notify(
-            string.format("Invalid third-party adapter: %s", error_message),
-            vim.log.levels.WARN
-          )
+          -- Already initialized eagerly by register_eager in setup(): its command
+          -- name is only known after calling setup(), so calling setup() again
+          -- here would duplicate any side effects and re-emit validation warnings.
         end
       elseif
         adapter_config.name and adapters.has_adapter(adapter_config.name)
       then
-        -- Handle built-in adapter
-        local default_adapter = adapters.get_adapter(adapter_config.name)
-        if default_adapter ~= nil then
-          local final_adapter =
-            adapters.override_adapter(default_adapter, adapter_config.opts)
-          table.insert(configured_adapters, final_adapter)
-        else
-          vim.notify(
-            string.format("Adapter %s not found", adapter_config.name),
-            vim.log.levels.WARN
-          )
-        end
+        ---@cast adapter_config GoDocBuiltinAdapter
+        adapter = configure_builtin_adapter(adapter_config, adapters)
       else
-        -- Handle user-defined adapter
-        local is_valid, error_message =
-          adapters.validate_adapter(adapter_config)
-        if is_valid then
-          table.insert(configured_adapters, adapter_config)
-        else
-          vim.notify(
-            string.format("Invalid user-defined adapter: %s", error_message),
-            vim.log.levels.WARN
-          )
-        end
+        ---@cast adapter_config GoDocUserAdapter
+        adapter = configure_user_adapter(adapter_config, adapters)
+      end
+
+      if adapter then
+        table.insert(configured_adapters, adapter)
       end
     end
   end
@@ -269,8 +303,7 @@ function M.setup(opts)
   end
 
   for _, adapter_config in ipairs(M.config.adapters) do
-    local command = (adapter_config.opts and adapter_config.opts.command)
-      or adapter_config.command
+    local command = configured_command(adapter_config)
     if command then
       -- Skip if a command with this name already exists (e.g., registered
       -- by another plugin, or the user's vimrc) — don't clobber.

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -185,32 +185,22 @@ local function register_command(command)
   end, { nargs = "?" })
 end
 
---- Run the built-in go adapter. Entry point for plugin/godoc.lua's :GoDoc so
---- that the command works out-of-the-box without the user calling setup().
---- Honors user overrides from M.config.adapters when setup() has been called.
+--- Entry point for the command auto-registered by plugin/godoc.lua, so it works
+--- out-of-the-box without the user calling setup(). Initializes the default
+--- adapters lazily (_ensure_initialized falls back to M.defaults) and dispatches
+--- the adapter whose command matches the one that was invoked.
 --- @param args table command arguments table from nvim_create_user_command
 function M._run_default_go(args)
-  local config = M.config or M.defaults
-  local adapters = require("godoc.adapters")
+  M._ensure_initialized()
 
-  local default_adapter = adapters.get_adapter("go")
-  if not default_adapter then
-    vim.notify("Built-in go adapter not available", vim.log.levels.ERROR)
+  local adapter = M._adapters[args.name]
+  if not adapter then
+    vim.notify(
+      "No adapter found for command: " .. args.name,
+      vim.log.levels.ERROR
+    )
     return
   end
-
-  -- Apply user's go adapter overrides (if any) so customizations propagate to :GoDoc.
-  local go_opts
-  for _, adapter_config in ipairs(config.adapters or {}) do
-    if adapter_config.name == "go" then
-      go_opts = adapter_config.opts
-      break
-    end
-  end
-  local adapter = adapters.override_adapter(default_adapter, go_opts)
-
-  local syntax = adapter.get_syntax_info()
-  vim.treesitter.language.register(syntax.language, { syntax.filetype })
 
   dispatch(adapter, args)
 end

--- a/lua/godoc/types.lua
+++ b/lua/godoc/types.lua
@@ -1,7 +1,9 @@
+--- User-supplied configuration. All fields are optional — anything you omit
+--- falls back to the defaults from `require("godoc").defaults`.
 --- @class GoDocConfig
---- @field adapters GoDocAdapterConfig[] List of adapter configurations
---- @field window GoDocWindowConfig Window configuration
---- @field picker GoDocPickerConfig Picker configuration
+--- @field adapters? GoDocAdapterConfig[] List of adapter configurations
+--- @field window? GoDocWindowConfig Window configuration
+--- @field picker? GoDocPickerConfig Picker configuration
 
 --- @class GoDocAdapter
 --- @field command string The vim command name to register

--- a/plugin/godoc.lua
+++ b/plugin/godoc.lua
@@ -1,24 +1,18 @@
 -- Auto-register :GoDoc with the built-in go adapter and default config so the
--- plugin works out of the box without the user calling require("godoc").setup().
---
--- Skipped entirely if:
---   * the plugin has already been loaded (vim.g.loaded_godoc),
---   * setup() was called before this file was sourced (vim.g._godoc_user_configured), or
---   * a :GoDoc command is already registered (e.g., by another plugin).
---
--- Users who want a different command name must call setup() themselves with a
--- free command name — see README for details.
+-- plugin works out of the box without require("godoc").setup().
 
 if vim.g.loaded_godoc then
   return
 end
 vim.g.loaded_godoc = true
 
-if vim.g._godoc_user_configured then
+if vim.g.godoc_user_configured then
   return
 end
 
-if vim.fn.exists(":GoDoc") > 0 then
+-- If another plugin owns :GoDoc, leave it alone. Users can call setup() with a
+-- different adapter command, for example { name = "go", opts = { command = "GoDocs" } }.
+if vim.api.nvim_get_commands({}).GoDoc ~= nil then
   return
 end
 
@@ -26,6 +20,5 @@ vim.api.nvim_create_user_command("GoDoc", function(args)
   require("godoc")._dispatch_command(args)
 end, { nargs = "?", desc = "Fuzzy search Go packages/symbols and view docs" })
 
--- Record the name we registered so setup() can remove exactly this command
--- without having to spell the name itself.
-vim.g._godoc_auto_registered = "GoDoc"
+-- Record the name so setup() can replace the zero-config command if needed.
+vim.g.godoc_auto_command = "GoDoc"

--- a/plugin/godoc.lua
+++ b/plugin/godoc.lua
@@ -1,0 +1,29 @@
+-- Auto-register :GoDoc with the built-in go adapter and default config so the
+-- plugin works out of the box without the user calling require("godoc").setup().
+--
+-- Skipped entirely if:
+--   * the plugin has already been loaded (vim.g.loaded_godoc),
+--   * setup() was called before this file was sourced (vim.g._godoc_user_configured), or
+--   * a :GoDoc command is already registered (e.g., by another plugin).
+--
+-- Users who want a different command name must call setup() themselves with a
+-- free command name — see README for details.
+
+if vim.g.loaded_godoc then
+  return
+end
+vim.g.loaded_godoc = true
+
+if vim.g._godoc_user_configured then
+  return
+end
+
+if vim.fn.exists(":GoDoc") > 0 then
+  return
+end
+
+vim.api.nvim_create_user_command("GoDoc", function(args)
+  require("godoc")._run_default_go(args)
+end, { nargs = "?", desc = "Fuzzy search Go packages/symbols and view docs" })
+
+vim.g._godoc_auto_registered = true

--- a/plugin/godoc.lua
+++ b/plugin/godoc.lua
@@ -23,7 +23,7 @@ if vim.fn.exists(":GoDoc") > 0 then
 end
 
 vim.api.nvim_create_user_command("GoDoc", function(args)
-  require("godoc")._run_default_go(args)
+  require("godoc")._dispatch_command(args)
 end, { nargs = "?", desc = "Fuzzy search Go packages/symbols and view docs" })
 
 -- Record the name we registered so setup() can remove exactly this command

--- a/plugin/godoc.lua
+++ b/plugin/godoc.lua
@@ -26,4 +26,6 @@ vim.api.nvim_create_user_command("GoDoc", function(args)
   require("godoc")._run_default_go(args)
 end, { nargs = "?", desc = "Fuzzy search Go packages/symbols and view docs" })
 
-vim.g._godoc_auto_registered = true
+-- Record the name we registered so setup() can remove exactly this command
+-- without having to spell the name itself.
+vim.g._godoc_auto_registered = "GoDoc"


### PR DESCRIPTION
## Summary

Adds `plugin/godoc.lua` so `:GoDoc` works out-of-the-box after install — no `require("godoc").setup()` call required unless the user wants customization. Follows [Neovim's plugin best practices](https://neovim.io/doc/user/lua-plugin/).

**Breaking** (major version bump): `:GoDoc` is now registered at Neovim startup (via `plugin/godoc.lua`) instead of only inside `setup()`. `setup()` also now skips commands that already exist instead of clobbering them.

## Behavior

`plugin/godoc.lua` registers `:GoDoc` at startup, bailing in three cases:

1. `vim.g.loaded_godoc` is already set (plugin disabled, or re-sourced)
2. `vim.g._godoc_user_configured` is set (user called `setup()` first — they own registration)
3. `:GoDoc` already exists (another plugin, user config, etc. — don't clobber)

`setup()` is deliberately non-destructive:

- Sets `vim.g._godoc_user_configured = true` so `plugin/godoc.lua` bails if it loads later
- Leaves the auto-registered `:GoDoc` alone **unless** the user's config explicitly claims the `"GoDoc"` command name for some adapter — then the auto-registered one is removed so that adapter can take it over
- Registers commands from `config.adapters`, skipping any that already exist (so nothing is clobbered)

## Matrix (all verified via headless nvim)

| Scenario | Result |
|---|---|
| No `setup()` call | `:GoDoc` auto-registered, uses defaults |
| `setup()` first, plugin file after | plugin file bails |
| `setup({ picker = "telescope" })` (no adapter change) | `:GoDoc` reassigned via `register_command` (defaults still include go → `"GoDoc"`) |
| `setup({ adapters = {{ go → :Foo }}})` | `:GoDoc` **stays** (defaults) alongside the new `:Foo` |
| `setup({ adapters = {{ go → :Foo }, { rust → :GoDoc }}})` | `:Foo` registered for go, `:GoDoc` reassigned to rust |
| Another plugin owns `:GoDoc` first | plugin file bails, no clobber |

## Internal cleanup

- Extracts the picker/dispatch flow from `register_command` into a shared `dispatch()` helper so both the lazy `register_command` callback and the new `_run_default_go` entry point share the same logic
- `setup()` skips commands that already exist instead of clobbering them

## Documentation

- Restructure the README: consolidate all `opts` docs into a single **Configuration** section (previously scattered across the lazy.nvim spec, the tree-sitter section, the adapters section, and a separate defaults block)
- Rewrite the tree-sitter syntax highlighting section to be plugin-manager-agnostic (discrete steps: install nvim-treesitter, register parser, configure godoc)
- Rewrite the **Adapters** section around a plain `setup()` example instead of embedding it inside a lazy.nvim spec
- Add `vim.pack` installation instructions (uses `vim.version.range("*")` to track any tagged release) and a `PackChanged` autocmd example for installing `stdsym@latest`
- Drop the `cmd = { "GoDoc" }` lazy.nvim hint — `plugin/godoc.lua` now handles lazy-loading
- Move the `ray-x/go.nvim` collision note from inside the lazy.nvim spec comment up to the Usage section
- Fix a bug in the tree-sitter example where the `TSUpdate` autocmd referenced an undefined `parser_config` variable
- All Lua code blocks now use 2-space indentation

Rendered README.md [here](https://github.com/fredrikaverpil/godoc.nvim/blob/feat/auto-register-godoc-command/README.md).

## Refs

- https://neovim.io/doc/user/lua-plugin/#_defer-require()-calls
- https://neovim.io/doc/user/starting/#initialization