### PR TITLE
feat!: work out of the box without setup()

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ Fuzzy search Go docs from within Neovim.
 
 > [!TIP]
 >
-> Extensible via adapters: bring your own language/data source (Python, Rust,
-> dad jokes — whatever you want to pick).
+> - **Works out of the box**: install the plugin and `:GoDoc` just works — no
+>   `setup()` call required. Loading is deferred until first use.
+> - **Extensible via adapters**: bring your own language/data source (Python,
+>   Rust, dad jokes — whatever you want to pick).
 
 ## Screenshots
 
@@ -50,9 +52,9 @@ _Screenshot is showing the Snacks picker._
 
 ## Installation
 
-Pick whichever plugin manager you use. The plugin is initialized by calling
-`require("godoc").setup()` — with lazy.nvim, `opts = {}` does this for you. See
-[Configuration](#configuration) for customization.
+Pick whichever plugin manager you use. `:GoDoc` works immediately after install
+— no `setup()` call required. See [Configuration](#configuration) if you want to
+customize.
 
 ### Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 
@@ -67,9 +69,6 @@ Pick whichever plugin manager you use. The plugin is initialized by calling
     { "ibhagwan/fzf-lua" }, -- optional
   },
   build = "go install github.com/lotusirous/gostdsym/stdsym@latest", -- optional
-  cmd = { "GoDoc" }, -- optional
-  ft = "godoc", -- optional
-  opts = {}, -- see Configuration
 }
 ```
 
@@ -90,9 +89,6 @@ vim.pack.add({
   { src = "https://github.com/echasnovski/mini.pick" },
   { src = "https://github.com/ibhagwan/fzf-lua" },
 })
-
--- Initialize the plugin (required), see Configuration
-require("godoc").setup()
 ```
 
 Optionally install [`stdsym`](https://github.com/lotusirous/gostdsym) (enables
@@ -125,11 +121,6 @@ Plug 'echasnovski/mini.pick'
 Plug 'ibhagwan/fzf-lua'
 
 Plug 'fredrikaverpil/godoc.nvim'
-
-" Initialize the plugin (required), see Configuration
-lua <<EOF
-require('godoc').setup()
-EOF
 ```
 
 ## Usage
@@ -149,15 +140,30 @@ The built-in `go` adapter provides:
 
 > [!WARNING]
 >
-> `:GoDoc` is also used by [ray-x/go.nvim](https://github.com/ray-x/go.nvim). To
-> avoid the collision, either pass `remap_commands = { GoDoc = false }` to
-> go.nvim or rename the godoc.nvim command (see
-> [Configuration](#configuration)).
+> `:GoDoc` is also used by [ray-x/go.nvim](https://github.com/ray-x/go.nvim). If
+> another plugin registers `:GoDoc` first, godoc.nvim leaves it alone. To avoid
+> the collision, either pass `remap_commands = { GoDoc = false }` to go.nvim or
+> rename the godoc.nvim command (see [Configuration](#configuration)).
 
 ## Configuration
 
-The plugin is initialized by calling `setup()` — any options you omit fall back
-to the defaults below.
+`:GoDoc` works with defaults out of the box. Call `setup()` only if you want to
+customize behavior — any options you omit fall back to the defaults below. Your
+`adapters` list then decides which commands exist: giving the go adapter a
+different command name replaces the default `:GoDoc`.
+
+> [!NOTE]
+>
+> With vim-plug (or any other Vimscript-based config), wrap the `setup()` call
+> in a Lua heredoc:
+>
+> ```vim
+> lua <<EOF
+> require("godoc").setup({
+>   -- your options
+> })
+> EOF
+> ```
 
 ```lua
 require("godoc").setup({

--- a/lua/godoc/health.lua
+++ b/lua/godoc/health.lua
@@ -6,12 +6,10 @@ function M.check()
   health.start("godoc.nvim")
 
   -- Check plugin setup
-  local config = require("godoc").config
-  if not config then
-    health.error("Plugin not configured")
-    return
+  if vim.g.godoc_did_setup then
+    health.ok("Plugin configured via setup()")
   else
-    health.ok("Plugin configured")
+    health.ok("Using default configuration (setup() was not called)")
   end
 
   -- Ensure adapters are initialized so health checks work even if no command has been run yet.

--- a/lua/godoc/init.lua
+++ b/lua/godoc/init.lua
@@ -4,9 +4,10 @@ local M = {}
 --- @type GoDocConfig
 M.defaults = require("godoc.config").defaults
 
--- Final configuration (defaults + user-provided) after setup.
+-- Active configuration. Starts as the defaults so the plugin works without a
+-- setup() call; setup() replaces it with the merged user config.
 --- @type GoDocConfig
-M.config = nil
+M.config = vim.deepcopy(M.defaults)
 
 -- The configured adapters, keyed by command name.
 --- @type table<string, GoDocAdapter>
@@ -248,6 +249,18 @@ end
 --- @param opts? GoDocConfig
 function M.setup(opts)
   M.config = require("godoc.config").setup(opts)
+
+  -- The user's config now owns command registration; make sure
+  -- plugin/godoc.lua doesn't auto-register :GoDoc if it runs after us.
+  vim.g.godoc_did_setup = true
+
+  -- Reclaim the :GoDoc auto-registered by plugin/godoc.lua so that the
+  -- configured adapters decide which commands exist: giving the go adapter
+  -- another command name replaces the default :GoDoc.
+  if vim.g.godoc_auto_registered then
+    pcall(vim.api.nvim_del_user_command, "GoDoc")
+    vim.g.godoc_auto_registered = nil
+  end
 
   -- Support re-running setup() (e.g. when reloading config): drop adapters
   -- resolved from a previous call so the new config takes effect.

--- a/plugin/godoc.lua
+++ b/plugin/godoc.lua
@@ -1,0 +1,27 @@
+-- Register :GoDoc at startup so the plugin works out of the box, without
+-- requiring a setup() call. See :h lua-plugin for the rationale.
+
+if vim.g.loaded_godoc then
+  return
+end
+vim.g.loaded_godoc = true
+
+-- The user already called setup() — their config owns command registration.
+if vim.g.godoc_did_setup then
+  return
+end
+
+-- Another plugin or the user's config owns :GoDoc — don't clobber it.
+if vim.api.nvim_get_commands({}).GoDoc ~= nil then
+  return
+end
+
+vim.api.nvim_create_user_command("GoDoc", function(args)
+  require("godoc")._dispatch_command("GoDoc", args)
+end, {
+  nargs = "?",
+  desc = "Fuzzy search Go packages/symbols and view docs",
+})
+
+-- Let setup() know it can reclaim this command when applying user config.
+vim.g.godoc_auto_registered = true


### PR DESCRIPTION
## Why?

- Final PR 3 of 3 toward [Neovim plugin best practices](https://neovim.io/doc/user/lua-plugin/) (after #60, #61; replaces #58)
- The plugin should work after install without a `setup()` call, with loading deferred until first use

## What?

- Add [plugin/godoc.lua](https://github.com/fredrikaverpil/godoc.nvim/blob/81be97e/plugin/godoc.lua): registers `:GoDoc` at startup with all `require()` calls deferred into the command callback
- It bails in three cases: plugin disabled (`vim.g.loaded_godoc`), `setup()` already ran (`vim.g.godoc_did_setup`), or another plugin owns `:GoDoc`
- `setup()` reclaims the auto-registered `:GoDoc` (`vim.g.godoc_auto_registered`), so the configured adapters decide which commands exist — **renaming the go adapter's command replaces the default `:GoDoc`**
- `M.config` starts as the defaults instead of `nil`
- `:checkhealth godoc` reports defaults-vs-setup() instead of erroring when unconfigured
- README: setup-now-optional wording, drop `cmd`/`ft`/`opts` lazy.nvim hints and the required `setup()` calls from the vim.pack/vim-plug sections, note that godoc.nvim never overwrites an existing `:GoDoc`

## Breaking

`:GoDoc` is registered at startup instead of by `setup()`. Users who relied on godoc.nvim staying inert until `setup()` (e.g. leaving `:GoDoc` to ray-x/go.nvim) can let the other plugin register first (never clobbered), call `setup()` during startup, or set `vim.g.loaded_godoc = true`.

## Verified (headless nvim)

| Scenario | Result |
|---|---|
| No `setup()` | `:GoDoc strings` renders docs with defaults |
| plugin file → `setup()` (lazy.nvim order) | `:GoDoc` reclaimed silently, works |
| plugin file → `setup()` renaming to `:GD` | `:GoDoc` removed, `:GD` works |
| `setup()` renaming to `:GD` → plugin file (vim.pack order) | plugin file bails, only `:GD` |
| Foreign `:GoDoc` first | plugin file bails; later `setup()` warns, no clobber |
| `vim.g.loaded_godoc = true` | nothing registered |
| `:checkhealth godoc` without setup | OK: "Using default configuration" |
